### PR TITLE
Remove trailing commas from CREATE TABLE statements

### DIFF
--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -128,7 +128,7 @@ CREATE TABLE commands (
 
     CHECK (command_uuid != ''),
     CHECK (request_type != ''),
-    CHECK (SUBSTRING(command FROM 1 FOR 5) = '<?xml'),
+    CHECK (SUBSTRING(command FROM 1 FOR 5) = '<?xml')
 );
 
 
@@ -166,7 +166,7 @@ CREATE TABLE command_results (
     -- capture results in the case they're malformed.
     CHECK (status != ''),
     INDEX (status),
-    CHECK (SUBSTRING(result FROM 1 FOR 5) = '<?xml'),
+    CHECK (SUBSTRING(result FROM 1 FOR 5) = '<?xml')
 );
 
 


### PR DESCRIPTION
## What's up? 

Was having problems running the schema.sql file in MySQL 5.7.32. It was blowing up because of the trailing commas.

Did some research on whether trailing commas are allowed in `CREATE TABLE`. The results didn't seem conclusive. Some RDBMS implementations deem it harmless and won't error on it. 

Wanted to check the SQL language spec next but since this file has some statement without trailing commas, I thought it's probably not intentional and it's easier to just remove it.