### PR TITLE
Fix typo in token_hex check constraint

### DIFF
--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -107,7 +107,7 @@ CREATE TABLE enrollments (
 
     CHECK (topic != ''),
     CHECK (push_magic != ''),
-    CHECK (LENGTH(token) > 0)
+    CHECK (LENGTH(token_hex) > 0)
 );
 
 


### PR DESCRIPTION
There's no `token` column on enrollments, but there is a `token_hex`, so assuming this check constraint is a typo. 

If that's the case, wondering how that worked? Is MySQL constraints in some versions more forgiving?