### PR TITLE
Accomodate large command results

### DIFF
--- a/storage/mysql/schema.00005.sql
+++ b/storage/mysql/schema.00005.sql
@@ -1,1 +1,1 @@
-ALTER TABLE command_results MODIFY result MEDIUMTEXT;
+ALTER TABLE command_results MODIFY result MEDIUMTEXT NOT NULL;

--- a/storage/mysql/schema.00005.sql
+++ b/storage/mysql/schema.00005.sql
@@ -1,0 +1,1 @@
+ALTER TABLE command_results MODIFY result LONGTEXT;

--- a/storage/mysql/schema.00005.sql
+++ b/storage/mysql/schema.00005.sql
@@ -1,1 +1,1 @@
-ALTER TABLE command_results MODIFY result LONGTEXT;
+ALTER TABLE command_results MODIFY result MEDIUMTEXT;

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -162,7 +162,7 @@ CREATE TABLE command_results (
     id           VARCHAR(255) NOT NULL,
     command_uuid VARCHAR(127) NOT NULL,
     status       VARCHAR(31)  NOT NULL,
-    result       MEDIUMTEXT     NOT NULL,
+    result       MEDIUMTEXT   NOT NULL,
 
     not_now_at    TIMESTAMP NULL,
     not_now_tally INTEGER NOT NULL DEFAULT 0,

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -162,7 +162,7 @@ CREATE TABLE command_results (
     id           VARCHAR(255) NOT NULL,
     command_uuid VARCHAR(127) NOT NULL,
     status       VARCHAR(31)  NOT NULL,
-    result       LONGTEXT     NOT NULL,
+    result       MEDIUMTEXT     NOT NULL,
 
     not_now_at    TIMESTAMP NULL,
     not_now_tally INTEGER NOT NULL DEFAULT 0,

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -162,7 +162,7 @@ CREATE TABLE command_results (
     id           VARCHAR(255) NOT NULL,
     command_uuid VARCHAR(127) NOT NULL,
     status       VARCHAR(31)  NOT NULL,
-    result       TEXT         NOT NULL,
+    result       LONGTEXT         NOT NULL,
 
     not_now_at    TIMESTAMP NULL,
     not_now_tally INTEGER NOT NULL DEFAULT 0,

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -162,7 +162,7 @@ CREATE TABLE command_results (
     id           VARCHAR(255) NOT NULL,
     command_uuid VARCHAR(127) NOT NULL,
     status       VARCHAR(31)  NOT NULL,
-    result       LONGTEXT         NOT NULL,
+    result       LONGTEXT     NOT NULL,
 
     not_now_at    TIMESTAMP NULL,
     not_now_tally INTEGER NOT NULL DEFAULT 0,


### PR DESCRIPTION
Hello!

When handling the command result response for InstalledApplicationList, nanomdm issues the following plea:

```
level=info handler=checkin-command msg=command report results err=storing command report: Error 1406: Data too long for column 'result' at row 1
```

The InstalledApplicationList response for my current device - with only base Apple apps - is 117,465 characters of base64-endcoded text. `TEXT` support 65,525 characters; `MEDIUMTEXT`, 16,777,215 (this corresponds to ~16.78 mb: "L + 3 bytes, where L < 2^24" -  https://dev.mysql.com/doc/refman/8.0/en/storage-requirements.html#data-types-storage-reqs-strings)

This works with current nanomdm release (in as much as I migrated with `schema.00005.sql` and everything continued to work/`InstalledApplicationList` started working). MySQL docs do not have any warnings regarding migrating between text types that I found.