### PR TITLE
HTTP codes (well, 500) for API responses

### DIFF
--- a/http/api.go
+++ b/http/api.go
@@ -45,6 +45,7 @@ type apiResult struct {
 // users.
 func PushHandlerFunc(pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		var hadServerError bool
 		ids := strings.Split(r.URL.Path, ",")
 		output := apiResult{
 			Status: make(enrolledAPIResults),
@@ -56,7 +57,6 @@ func PushHandlerFunc(pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 			hadServerError = true
 		}
 		var ct, errCt int
-		var hadServerError bool
 		for id, resp := range pushResp {
 			output.Status[id] = &enrolledAPIResult{
 				PushResult: resp.Id,

--- a/http/api.go
+++ b/http/api.go
@@ -56,7 +56,7 @@ func PushHandlerFunc(pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 			hadServerError = true
 		}
 		var ct, errCt int
-		var hadServerError bool = false
+		var hadServerError bool
 		for id, resp := range pushResp {
 			output.Status[id] = &enrolledAPIResult{
 				PushResult: resp.Id,
@@ -115,7 +115,7 @@ func RawCommandEnqueueHandler(enqueuer storage.CommandEnqueuer, pusher push.Push
 			CommandUUID: command.CommandUUID,
 			RequestType: command.Command.RequestType,
 		}
-		var hadServerError bool = false
+		var hadServerError bool
 		idErrs, err := enqueuer.EnqueueCommand(r.Context(), ids, command)
 		if err != nil {
 			logger.Info("msg", "enqueue command", "err", err)
@@ -195,7 +195,7 @@ func StorePushCertHandlerFunc(storage storage.PushCertStore, logger log.Logger) 
 		var pemKey []byte
 		var topic string
 		var block *pem.Block
-		var hadServerError bool = false
+		var hadServerError bool
 		for {
 			block, b = pem.Decode(b)
 			if block == nil {


### PR DESCRIPTION
In lieu of parsing responses for `push_error` etc, I would prefer to rely on the HTTP code to judge success. This is a bit awkward when enqueuing commands for multiple IDs, as not all may have failed. I argue to that one failure should return 500 for the entire operation - if the client sent multiple IDs, it is the client's responsibility to read the json response and discover the precise error.

I didn't get fancy with specific error codes, willing to though.

I'm a go noob, so I apologize for any glaring mistake, bad pattern, etc. Please let me know!