### PR TITLE
add support for ScheduleOSUpdate to cmdr.py

### DIFF
--- a/tools/cmdr.py
+++ b/tools/cmdr.py
@@ -80,7 +80,7 @@ def sched_update_subparser(parser):
     )
     sched_update_parser.add_argument(
         "--deferrals",
-        type=str,
+        type=int,
         help="MaxUserDeferrals (ex. 3, 30, etc.)",
     )
     sched_update_parser.add_argument(
@@ -196,7 +196,6 @@ def main():
         "EnableRemoteDesktop",
         "DisableRemoteDesktop",
         "ActivationLockBypassCode",
-        "ScheduleOSUpdate",
     ]:
         simple_command_subparser(c, subparsers)
 

--- a/tools/cmdr.py
+++ b/tools/cmdr.py
@@ -41,6 +41,57 @@ def dev_info(args):
     return c
 
 
+def sched_update(args):
+    c = {
+        "RequestType": "ScheduleOSUpdate",
+        "Updates": [
+            {"InstallAction": args.action}
+        ],
+    }
+    if hasattr(args, "version") and args.version:
+        c["Updates"][0]["ProductVersion"] = args.version
+    if hasattr(args, "key") and args.key:
+        c["Updates"][0]["ProductKey"] = args.key
+    if hasattr(args, "deferrals") and args.deferrals:
+        c["Updates"][0]["MaxUserDeferrals"] = args.deferrals
+    if hasattr(args, "priority") and args.priority:
+        c["Updates"][0]["Priority"] = args.priority
+    return c
+
+
+def sched_update_subparser(parser):
+    sched_update_parser = parser.add_parser(
+        "ScheduleOSUpdate", help="ScheduleOSUpdate MDM command"
+    )
+    sched_update_parser.add_argument(
+        "action",
+        type=str,
+        help="InstallAction (ex. InstallASAP, InstallLater, etc.)",
+    )
+    sched_update_parser.add_argument(
+        "--version",
+        type=str,
+        help="ProductVersion (ex. 12.1, 12.2.1, etc.)",
+    )
+    sched_update_parser.add_argument(
+        "--key",
+        type=str,
+        help="ProductKey (ex. MSU_UPDATE_21E5227a_patch_12.3, etc.)",
+    )
+    sched_update_parser.add_argument(
+        "--deferrals",
+        type=str,
+        help="MaxUserDeferrals (ex. 3, 30, etc.)",
+    )
+    sched_update_parser.add_argument(
+        "--priority",
+        type=str,
+        help="Priority (ex. Low, High.)",
+    )
+    sched_update_parser.set_defaults(func=sched_update)
+    return sched_update_parser
+
+
 def dev_info_subparser(parser):
     dev_info_parser = parser.add_parser(
         "DeviceInformation", help="DeviceInformation MDM command"
@@ -145,12 +196,14 @@ def main():
         "EnableRemoteDesktop",
         "DisableRemoteDesktop",
         "ActivationLockBypassCode",
+        "ScheduleOSUpdate",
     ]:
         simple_command_subparser(c, subparsers)
 
     dev_info_subparser(subparsers)
     inst_prof_subparser(subparsers)
     rem_prof_subparser(subparsers)
+    sched_update_subparser(subparsers)
 
     command_subparser(subparsers)
 


### PR DESCRIPTION
```
usage: cmdr.py ScheduleOSUpdate [-h] [--version VERSION] [--key KEY]
                                [--deferrals DEFERRALS] [--priority PRIORITY]
                                action

positional arguments:
  action                InstallAction (ex. InstallASAP, InstallLater, etc.)

optional arguments:
  -h, --help            show this help message and exit
  --version VERSION     ProductVersion (ex. 12.1, 12.2.1, etc.)
  --key KEY             ProductKey (ex. MSU_UPDATE_21E5227a_patch_12.3, etc.)
  --deferrals DEFERRALS
                        MaxUserDeferrals (ex. 3, 30, etc.)
  --priority PRIORITY   Priority (ex. Low, High.)
```
Example
```
 % ./cmdr.py ScheduleOSUpdate InstallASAP --version 12.1 --deferrals 3
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>Command</key>
	<dict>
		<key>RequestType</key>
		<string>ScheduleOSUpdate</string>
		<key>Updates</key>
		<array>
			<dict>
				<key>InstallAction</key>
				<string>InstallASAP</string>
				<key>MaxUserDeferrals</key>
				<string>3</string>
				<key>ProductVersion</key>
				<string>12.1</string>
			</dict>
		</array>
	</dict>
	<key>CommandUUID</key>
	<string>a1fc9d95-88af-43db-ab85-164607cc944a</string>
</dict>
</plist>
```