### PR TITLE
Context logging

### DIFF
--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -1,20 +1,24 @@
 package main
 
 import (
+	"context"
 	"crypto/subtle"
 	"crypto/x509"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	stdlog "log"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/micromdm/nanomdm/certverify"
 	"github.com/micromdm/nanomdm/cmd/cli"
 	mdmhttp "github.com/micromdm/nanomdm/http"
 	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/log/stdlogfmt"
 	"github.com/micromdm/nanomdm/push/buford"
 	pushsvc "github.com/micromdm/nanomdm/push/service"
@@ -196,6 +200,8 @@ func main() {
 		w.Write([]byte(`{"version":"` + version + `"}`))
 	})
 
+	rand.Seed(time.Now().UnixNano())
+
 	logger.Info("msg", "starting server", "listen", *flListen)
 	err = http.ListenAndServe(*flListen, simpleLog(mux, logger.With("handler", "log")))
 	logs := []interface{}{"msg", "server shutdown"}
@@ -219,8 +225,25 @@ func basicAuth(next http.Handler, username, password, realm string) http.Handler
 	}
 }
 
+type ctxKeyTraceID struct{}
+
+// storeNewTraceID generates a new trace identifier and stores it on
+// the context.
+func storeNewTraceID(ctx context.Context) context.Context {
+	// currently this just makes a random string. this would be better
+	// served by e.g. https://github.com/oklog/ulid or something like
+	// https://opentelemetry.io/ someday.
+	b := make([]byte, 8)
+	rand.Read(b)
+	id := fmt.Sprintf("%x", b)
+	return context.WithValue(ctx, ctxKeyTraceID{}, id)
+}
+
 func simpleLog(next http.Handler, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := storeNewTraceID(r.Context())
+		ctx = ctxlog.AddFunc(ctx, ctxlog.SimpleStringFunc(ctxKeyTraceID{}, "trace_id"))
+		logger := ctxlog.Logger(ctx, logger)
 		host, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
 			host = r.RemoteAddr
@@ -235,6 +258,6 @@ func simpleLog(next http.Handler, logger log.Logger) http.HandlerFunc {
 			logs = append(logs, "real_ip", fwdedFor)
 		}
 		logger.Info(logs...)
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	}
 }

--- a/http/api.go
+++ b/http/api.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/micromdm/nanomdm/cryptoutil"
 	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/push"
 	"github.com/micromdm/nanomdm/storage"
@@ -45,6 +46,7 @@ type apiResult struct {
 // users.
 func PushHandlerFunc(pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
 		ids := strings.Split(r.URL.Path, ",")
 		output := apiResult{
 			Status: make(enrolledAPIResults),
@@ -88,6 +90,7 @@ func PushHandlerFunc(pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 // for "API" users.
 func RawCommandEnqueueHandler(enqueuer storage.CommandEnqueuer, pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
 		b, err := ReadAllAndReplaceBody(r)
 		if err != nil {
 			logger.Info("msg", "reading body", "err", err)
@@ -169,6 +172,7 @@ func RawCommandEnqueueHandler(enqueuer storage.CommandEnqueuer, pusher push.Push
 // upload our push certs.
 func StorePushCertHandlerFunc(storage storage.PushCertStore, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
 		b, err := ReadAllAndReplaceBody(r)
 		if err != nil {
 			logger.Info("msg", "reading body", "err", err)

--- a/http/mdm.go
+++ b/http/mdm.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/service"
 )
@@ -26,6 +27,7 @@ func mdmReqFromHTTPReq(r *http.Request) *mdm.Request {
 // CheckinHandlerFunc decodes an MDM check-in request and adapts it to service.
 func CheckinHandlerFunc(svc service.Checkin, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
 		bodyBytes, err := ReadAllAndReplaceBody(r)
 		if err != nil {
 			logger.Info("msg", "reading body", "err", err)
@@ -49,6 +51,7 @@ func CheckinHandlerFunc(svc service.Checkin, logger log.Logger) http.HandlerFunc
 // CommandAndReportResultsHandlerFunc decodes an MDM command request and adapts it to service.
 func CommandAndReportResultsHandlerFunc(svc service.CommandAndReportResults, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
 		bodyBytes, err := ReadAllAndReplaceBody(r)
 		if err != nil {
 			logger.Info("msg", "reading body", "err", err)

--- a/log/ctxlog/ctxlog.go
+++ b/log/ctxlog/ctxlog.go
@@ -1,0 +1,62 @@
+// Package ctxlog allows logging data stored with a context.
+package ctxlog
+
+import (
+	"context"
+	"sync"
+
+	"github.com/micromdm/nanomdm/log"
+)
+
+// CtxKVFunc creates logger key-value pairs from a context.
+type CtxKVFunc func(context.Context) []interface{}
+
+// ctxKeyFuncs is the context key for storing and retriveing
+// a funcs{} struct on a context.
+type ctxKeyFuncs struct{}
+
+// funcs holds the associated CtxKVFunc functions to run.
+type funcs struct {
+	sync.RWMutex
+	funcs []CtxKVFunc
+}
+
+// AddFunc associates a new CtxKVFunc function to a context.
+func AddFunc(ctx context.Context, f CtxKVFunc) context.Context {
+	ctxFuncs, ok := ctx.Value(ctxKeyFuncs{}).(*funcs)
+	if !ok || ctxFuncs == nil {
+		ctxFuncs = &funcs{}
+	}
+	ctxFuncs.Lock()
+	ctxFuncs.funcs = append(ctxFuncs.funcs, f)
+	ctxFuncs.Unlock()
+	return context.WithValue(ctx, ctxKeyFuncs{}, ctxFuncs)
+}
+
+// Logger runs the associated CtxKVFunc functions and returns a new
+// logger with the results.
+func Logger(ctx context.Context, logger log.Logger) log.Logger {
+	ctxFuncs, ok := ctx.Value(ctxKeyFuncs{}).(*funcs)
+	if !ok {
+		return logger
+	}
+	var acc []interface{}
+	ctxFuncs.RLock()
+	for _, f := range ctxFuncs.funcs {
+		acc = append(acc, f(ctx)...)
+	}
+	ctxFuncs.RUnlock()
+	return logger.With(acc...)
+}
+
+// SimpleStringFunc is a helper that generates a simple CtxKVFunc that
+// returns a key-value pair if found on the context.
+func SimpleStringFunc(ctxKey interface{}, logKey string) CtxKVFunc {
+	return func(ctx context.Context) (out []interface{}) {
+		v, _ := ctx.Value(ctxKey).(string)
+		if v != "" {
+			out = append(out, logKey, v)
+		}
+		return
+	}
+}

--- a/push/service/service.go
+++ b/push/service/service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/push"
 	"github.com/micromdm/nanomdm/storage"
@@ -64,7 +65,10 @@ func (s *PushService) getProvider(ctx context.Context, topic string) (push.PushP
 	if err != nil {
 		return nil, fmt.Errorf("retrieving push cert for topic %q: %w", topic, err)
 	}
-	s.logger.Info("msg", "retrieved push cert", "topic", topic)
+	ctxlog.Logger(ctx, s.logger).Info(
+		"msg", "retrieved push cert",
+		"topic", topic,
+	)
 	newProvider, err := s.providerFactory.NewPushProvider(cert)
 	if err != nil {
 		return nil, fmt.Errorf("creating new push provider: %w", err)
@@ -114,7 +118,10 @@ func (s *PushService) pushMulti(ctx context.Context, pushInfos []*mdm.Push) (map
 	for topic, pushInfos := range topicToPushInfos {
 		prov, err := s.getProvider(ctx, topic)
 		if err != nil {
-			s.logger.Info("msg", "get provider", "err", err)
+			ctxlog.Logger(ctx, s.logger).Info(
+				"msg", "get provider",
+				"err", err,
+			)
 			finalErr = err
 			continue
 		}
@@ -191,7 +198,9 @@ func (s *PushService) Push(ctx context.Context, ids []string) (map[string]*push.
 	for token, resp := range tokenToResponse {
 		id, ok := tokenToId[token]
 		if !ok {
-			s.logger.Info("msg", "could not find id by token")
+			ctxlog.Logger(ctx, s.logger).Info(
+				"msg", "could not find id by token",
+			)
 			continue
 		}
 		idToResponse[id] = resp

--- a/service/certauth/certauth.go
+++ b/service/certauth/certauth.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/service"
 	"github.com/micromdm/nanomdm/storage"
@@ -110,6 +111,7 @@ func (s *CertAuth) associateNewEnrollment(r *mdm.Request) error {
 	if err := r.EnrollID.Validate(); err != nil {
 		return err
 	}
+	logger := ctxlog.Logger(r.Context, s.logger)
 	hash := hashCert(r.Certificate)
 	if hasHash, err := s.storage.HasCertHash(r, hash); err != nil {
 		return err
@@ -124,7 +126,7 @@ func (s *CertAuth) associateNewEnrollment(r *mdm.Request) error {
 			} else if isAssoc {
 				return nil
 			}
-			s.logger.Info(
+			logger.Info(
 				"msg", "cert hash exists",
 				"enrollment", "new",
 				"id", r.ID,
@@ -138,7 +140,7 @@ func (s *CertAuth) associateNewEnrollment(r *mdm.Request) error {
 	if err := s.storage.AssociateCertHash(r, hash); err != nil {
 		return err
 	}
-	s.logger.Info(
+	logger.Info(
 		"msg", "cert associated",
 		"enrollment", "new",
 		"id", r.ID,
@@ -154,6 +156,7 @@ func (s *CertAuth) validateAssociateExistingEnrollment(r *mdm.Request) error {
 	if err := r.EnrollID.Validate(); err != nil {
 		return err
 	}
+	logger := ctxlog.Logger(r.Context, s.logger)
 	hash := hashCert(r.Certificate)
 	if isAssoc, err := s.storage.IsCertHashAssociated(r, hash); err != nil {
 		return err
@@ -161,7 +164,7 @@ func (s *CertAuth) validateAssociateExistingEnrollment(r *mdm.Request) error {
 		return nil
 	}
 	if !s.allowRetroactive {
-		s.logger.Info(
+		logger.Info(
 			"msg", "no cert association",
 			"enrollment", "existing",
 			"id", r.ID,
@@ -178,7 +181,7 @@ func (s *CertAuth) validateAssociateExistingEnrollment(r *mdm.Request) error {
 	if hasHash, err := s.storage.EnrollmentHasCertHash(r, hash); err != nil {
 		return err
 	} else if hasHash {
-		s.logger.Info(
+		logger.Info(
 			"msg", "enrollment cannot have associated cert hash",
 			"enrollment", "existing",
 			"id", r.ID,
@@ -195,7 +198,7 @@ func (s *CertAuth) validateAssociateExistingEnrollment(r *mdm.Request) error {
 	if hasHash, err := s.storage.HasCertHash(r, hash); err != nil {
 		return err
 	} else if hasHash {
-		s.logger.Info(
+		logger.Info(
 			"msg", "cert hash exists",
 			"enrollment", "existing",
 			"id", r.ID,
@@ -211,7 +214,7 @@ func (s *CertAuth) validateAssociateExistingEnrollment(r *mdm.Request) error {
 	if err := s.storage.AssociateCertHash(r, hash); err != nil {
 		return err
 	}
-	s.logger.Info(
+	logger.Info(
 		"msg", "cert associated",
 		"enrollment", "existing",
 		"id", r.ID,

--- a/service/nanomdm/ctxlog.go
+++ b/service/nanomdm/ctxlog.go
@@ -1,0 +1,38 @@
+package nanomdm
+
+import (
+	"context"
+
+	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
+	"github.com/micromdm/nanomdm/mdm"
+)
+
+type (
+	ctxKeyID   struct{}
+	ctxKeyType struct{}
+)
+
+func newContext(ctx context.Context, r *mdm.Request) context.Context {
+	newCtx := context.WithValue(ctx, ctxKeyID{}, r.ID)
+	return context.WithValue(newCtx, ctxKeyType{}, r.Type)
+}
+
+func ctxKVs(ctx context.Context) (out []interface{}) {
+	id, ok := ctx.Value(ctxKeyID{}).(string)
+	if ok {
+		out = append(out, "id", id)
+	}
+	eType, ok := ctx.Value(ctxKeyType{}).(mdm.EnrollType)
+	if ok {
+		out = append(out, "type", eType)
+	}
+	return
+}
+
+// ctxLogger sets up and returns a new contextual logger
+func (s *Service) ctxLogger(r *mdm.Request) log.Logger {
+	r.Context = newContext(r.Context, r)
+	r.Context = ctxlog.AddFunc(r.Context, ctxKVs)
+	return ctxlog.Logger(r.Context, s.logger)
+}

--- a/storage/allmulti/allmulti.go
+++ b/storage/allmulti/allmulti.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/storage"
 )
@@ -32,7 +33,7 @@ type returnCollector struct {
 
 type errRunner func(storage.AllStorage) (interface{}, error)
 
-func (ms *MultiAllStorage) execStores(r errRunner) (interface{}, error) {
+func (ms *MultiAllStorage) execStores(ctx context.Context, r errRunner) (interface{}, error) {
 	retChan := make(chan *returnCollector)
 	for i, store := range ms.stores {
 		go func(n int, s storage.AllStorage) {
@@ -52,42 +53,45 @@ func (ms *MultiAllStorage) execStores(r errRunner) (interface{}, error) {
 			finalErr = sErr.err
 			finalValue = sErr.returnValue
 		} else if sErr.err != nil {
-			ms.logger.Info("n", sErr.storeNumber, "err", sErr.err)
+			ctxlog.Logger(ctx, ms.logger).Info(
+				"n", sErr.storeNumber,
+				"err", sErr.err,
+			)
 		}
 	}
 	return finalValue, finalErr
 }
 
 func (ms *MultiAllStorage) StoreAuthenticate(r *mdm.Request, msg *mdm.Authenticate) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreAuthenticate(r, msg)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) StoreTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreTokenUpdate(r, msg)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) RetrieveTokenUpdateTally(ctx context.Context, id string) (int, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
 		return s.RetrieveTokenUpdateTally(ctx, id)
 	})
 	return val.(int), err
 }
 
 func (ms *MultiAllStorage) StoreUserAuthenticate(r *mdm.Request, msg *mdm.UserAuthenticate) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreUserAuthenticate(r, msg)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) Disable(r *mdm.Request) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.Disable(r)
 	})
 	return err

--- a/storage/allmulti/bstoken.go
+++ b/storage/allmulti/bstoken.go
@@ -6,14 +6,14 @@ import (
 )
 
 func (ms *MultiAllStorage) StoreBootstrapToken(r *mdm.Request, msg *mdm.SetBootstrapToken) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreBootstrapToken(r, msg)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) RetrieveBootstrapToken(r *mdm.Request, msg *mdm.GetBootstrapToken) (*mdm.BootstrapToken, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return s.RetrieveBootstrapToken(r, msg)
 	})
 	return val.(*mdm.BootstrapToken), err

--- a/storage/allmulti/certauth.go
+++ b/storage/allmulti/certauth.go
@@ -6,28 +6,28 @@ import (
 )
 
 func (ms *MultiAllStorage) HasCertHash(r *mdm.Request, hash string) (bool, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return s.HasCertHash(r, hash)
 	})
 	return val.(bool), err
 }
 
 func (ms *MultiAllStorage) EnrollmentHasCertHash(r *mdm.Request, hash string) (bool, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return s.EnrollmentHasCertHash(r, hash)
 	})
 	return val.(bool), err
 }
 
 func (ms *MultiAllStorage) IsCertHashAssociated(r *mdm.Request, hash string) (bool, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return s.IsCertHashAssociated(r, hash)
 	})
 	return val.(bool), err
 }
 
 func (ms *MultiAllStorage) AssociateCertHash(r *mdm.Request, hash string) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.AssociateCertHash(r, hash)
 	})
 	return err

--- a/storage/allmulti/push.go
+++ b/storage/allmulti/push.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (ms *MultiAllStorage) RetrievePushInfo(ctx context.Context, ids []string) (map[string]*mdm.Push, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
 		return s.RetrievePushInfo(ctx, ids)
 	})
 	return val.(map[string]*mdm.Push), err

--- a/storage/allmulti/pushcert.go
+++ b/storage/allmulti/pushcert.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (ms *MultiAllStorage) IsPushCertStale(ctx context.Context, topic string, staleToken string) (bool, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
 		return s.IsPushCertStale(ctx, topic, staleToken)
 	})
 	return val.(bool), err
@@ -20,7 +20,7 @@ type retrievePushCertReturns struct {
 }
 
 func (ms *MultiAllStorage) RetrievePushCert(ctx context.Context, topic string) (cert *tls.Certificate, staleToken string, err error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
 		rets := new(retrievePushCertReturns)
 		var err error
 		rets.cert, rets.staleToken, err = s.RetrievePushCert(ctx, topic)
@@ -31,7 +31,7 @@ func (ms *MultiAllStorage) RetrievePushCert(ctx context.Context, topic string) (
 }
 
 func (ms *MultiAllStorage) StorePushCert(ctx context.Context, pemCert, pemKey []byte) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StorePushCert(ctx, pemCert, pemKey)
 	})
 	return err

--- a/storage/allmulti/queue.go
+++ b/storage/allmulti/queue.go
@@ -8,28 +8,28 @@ import (
 )
 
 func (ms *MultiAllStorage) StoreCommandReport(r *mdm.Request, report *mdm.CommandResults) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreCommandReport(r, report)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) RetrieveNextCommand(r *mdm.Request, skipNotNow bool) (*mdm.Command, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return s.RetrieveNextCommand(r, skipNotNow)
 	})
 	return val.(*mdm.Command), err
 }
 
 func (ms *MultiAllStorage) ClearQueue(r *mdm.Request) error {
-	_, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.ClearQueue(r)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) EnqueueCommand(ctx context.Context, id []string, cmd *mdm.Command) (map[string]error, error) {
-	val, err := ms.execStores(func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
 		return s.EnqueueCommand(ctx, id, cmd)
 	})
 	return val.(map[string]error), err

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/micromdm/nanomdm/cryptoutil"
 	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 )
 
@@ -117,7 +118,9 @@ func (s *MySQLStorage) storeUserTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate
 	// there shouldn't be an Unlock Token on the user channel, but
 	// complain if there is to warn an admin
 	if len(msg.UnlockToken) > 0 {
-		s.logger.Info("msg", "Unlock Token on user channel not stored")
+		ctxlog.Logger(r.Context, s.logger).Info(
+			"msg", "Unlock Token on user channel not stored",
+		)
 	}
 	_, err := s.db.ExecContext(
 		r.Context, `


### PR DESCRIPTION
Adds a simple `ctxlog` package which permits associating multiple `CtxKVFunc`s with a context. Then, when it's time to log, these are ran using the request context to pull out logging key-value pairs and create a new logger.

The end result is something like this for a typical NanoMDM push request.

Before:

```
2022/03/16 14:03:09 level=info handler=log addr=::1 method=GET path=/v1/push/D7083AF3-DCCB-5661-A678-BCE8F4D9A2C8 agent=curl/7.64.1
2022/03/16 14:03:09 level=info service=push msg=retrieved push cert topic=com.apple.mgmt.External.deadbeef-1f17-4c8e-8a63-dd17d3dd35d9
2022/03/16 14:03:09 level=debug handler=push msg=push count=1 errs=0
2022/03/16 14:03:09 level=info handler=log addr=192.168.0.2 method=PUT path=/mdm agent=MDM-OSX/1.0 mdmclient/1455 real_ip=2301:602:8a02:9b0f:422:25a8:481b:bd42
2022/03/16 14:03:09 level=info service=nanomdm status=Idle id=D7083AF3-DCCB-5661-A678-BCE8F4D9A2C8 type=Device
2022/03/16 14:03:09 level=debug service=nanomdm msg=no command retrieved id=D7083AF3-DCCB-5661-A678-BCE8F4D9A2C8
```

After:


```
2022/03/16 14:02:44 level=info handler=log trace_id=84172eff419691ca addr=::1 method=GET path=/v1/push/D7083AF3-DCCB-5661-A678-BCE8F4D9A2C8 agent=curl/7.64.1
2022/03/16 14:02:44 level=info service=push trace_id=84172eff419691ca msg=retrieved push cert topic=com.apple.mgmt.External.deadbeef-1f17-4c8e-8a63-dd17d3dd35d9
2022/03/16 14:02:44 level=debug handler=push trace_id=84172eff419691ca msg=push count=1 errs=0
2022/03/16 14:02:44 level=info handler=log trace_id=c35015253617eb34 addr=192.168.0.2 method=PUT path=/mdm agent=MDM-OSX/1.0 mdmclient/1455 real_ip=2301:602:8a02:9b0f:422:25a8:481b:bd42
2022/03/16 14:02:45 level=info service=nanomdm trace_id=c35015253617eb34 id=D7083AF3-DCCB-5661-A678-BCE8F4D9A2C8 type=Device status=Idle
2022/03/16 14:02:45 level=debug service=nanomdm trace_id=c35015253617eb34 id=D7083AF3-DCCB-5661-A678-BCE8F4D9A2C8 type=Device msg=no command retrieved
```


Note the `trace_id` value which tracks each log's request from its origin. Note also that `id` and `type` in the `service=nanomdm` layer is also a context value rather than explicitly logged now.