### PR TITLE
Optionally delete commands in mysql storage backend

### DIFF
--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -59,7 +59,7 @@ Configures the MySQL storage backend. The `-dsn` flag should be in the [format t
 Options are specified as a comma-separated list of "key=value" pairs. The mysql backend supports these options:
 
 * `delete=1`, `delete=0`
-  * This option turns on the command and response deleter. When enabled (with `delete=1`) command responses, queued commands, and commands themeselves will be deleted from the database after enrollments have responded to a command.
+  * This option turns on or off the command and response deleter. It is disabled by default. When enabled (with `delete=1`) command responses, queued commands, and commands themeselves will be deleted from the database after enrollments have responded to a command.
 
 *Example:* `-storage mysql -dsn nanomdm:nanomdm/mymdmdb -storage-options delete=1`
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -44,7 +44,7 @@ The `-storage`, `-dsn`, & `-storage-options` flags together configure the storag
 
 * `-storage file`
 
-Configures the `file` storage backend. This manages enrollment and command data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-dsn` flag specifies the filesystem directory for the database.
+Configures the `file` storage backend. This manages enrollment and command data within plain filesystem files and directories. It has zero dependencies and should run out of the box. The `-dsn` flag specifies the filesystem directory for the database. The `file` backend has no storage options.
 
 *Example:* `-storage file -dsn /path/to/my/db`
 
@@ -55,6 +55,13 @@ Configures the `file` storage backend. This manages enrollment and command data 
 Configures the MySQL storage backend. The `-dsn` flag should be in the [format the SQL driver expects](https://github.com/go-sql-driver/mysql#dsn-data-source-name). Be sure to create your tables with the [schema.sql](../storage/mysql/schema.sql) file that corresponds to your NanoMDM version. Also make sure you apply any schema changes for each updated version (i.e. execute the numbered schema change files). MySQL 8.0.19 or later is required.
 
 *Example:* `-storage mysql -dsn nanomdm:nanomdm/mymdmdb`
+
+Options are specified as a comma-separated list of "key=value" pairs. The mysql backend supports these options:
+
+* `delete=1`, `delete=0`
+  * This option turns on the command and response deleter. When enabled (with `delete=1`) command responses, queued commands, and commands themeselves will be deleted from the database after enrollments have responded to a command.
+
+*Example:* `-storage mysql -dsn nanomdm:nanomdm/mymdmdb -storage-options delete=1`
 
 #### multi-storage backend
 

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -18,6 +18,7 @@ var ErrNoCert = errors.New("no certificate in MDM Request")
 type MySQLStorage struct {
 	logger log.Logger
 	db     *sql.DB
+	rm     bool
 }
 
 type config struct {
@@ -25,6 +26,7 @@ type config struct {
 	dsn    string
 	db     *sql.DB
 	logger log.Logger
+	rm     bool
 }
 
 type Option func(*config)
@@ -53,6 +55,12 @@ func WithDB(db *sql.DB) Option {
 	}
 }
 
+func WithDeleteCommands() Option {
+	return func(c *config) {
+		c.rm = true
+	}
+}
+
 func New(opts ...Option) (*MySQLStorage, error) {
 	cfg := &config{logger: log.NopLogger, driver: "mysql"}
 	for _, opt := range opts {
@@ -68,7 +76,7 @@ func New(opts ...Option) (*MySQLStorage, error) {
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}
-	return &MySQLStorage{db: cfg.db, logger: cfg.logger}, nil
+	return &MySQLStorage{db: cfg.db, logger: cfg.logger, rm: cfg.rm}, nil
 }
 
 // nullEmptyString returns a NULL string if s is empty.

--- a/storage/mysql/queue_test.go
+++ b/storage/mysql/queue_test.go
@@ -87,7 +87,7 @@ func TestQueue(t *testing.T) {
 		t.Fatal("MySQL DSN flag not provided to test")
 	}
 
-	storage, err := New(WithDSN(*flDSN))
+	storage, err := New(WithDSN(*flDSN), WithDeleteCommands())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,5 +97,16 @@ func TestQueue(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	test.TestQueue(t, deviceUDID, storage)
+	t.Run("WithDeleteCommands()", func(t *testing.T) {
+		test.TestQueue(t, deviceUDID, storage)
+	})
+
+	storage, err = New(WithDSN(*flDSN))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("normal", func(t *testing.T) {
+		test.TestQueue(t, deviceUDID, storage)
+	})
 }


### PR DESCRIPTION
From the changes to the operations guide:

> This option turns on the command and response deleter. When enabled (with `delete=1`) command responses, queued commands, and commands themeselves will be deleted from the database after enrollments have responded to a command.

This implements the feature discussed in #43 for the `mysql` storage backend.