### PR TITLE
Add Logging for plist parse errors

### DIFF
--- a/http/mdm/mdm.go
+++ b/http/mdm/mdm.go
@@ -37,12 +37,21 @@ func CheckinHandler(svc service.Checkin, logger log.Logger) http.HandlerFunc {
 		}
 		respBytes, err := service.CheckinRequest(svc, mdmReqFromHTTPReq(r), bodyBytes)
 		if err != nil {
-			logger.Info("msg", "check-in request", "err", err)
+			logs := []interface{}{"msg", "check-in request"}
 			httpStatus := http.StatusInternalServerError
 			var statusErr *service.HTTPStatusError
 			if errors.As(err, &statusErr) {
 				httpStatus = statusErr.Status
+				err = statusErr.Unwrap()
 			}
+			// manualy unwrapping the `StatusErr` is not necessary as `errors.As` manually unwraps
+			var parseErr *mdm.ParseError
+			if errors.As(err, &parseErr) {
+				logs = append(logs, "content", string(parseErr.Content))
+				err = statusErr.Unwrap()
+			}
+			logs = append(logs, "http_status", httpStatus, "err", err)
+			logger.Info(logs...)
 			http.Error(w, http.StatusText(httpStatus), httpStatus)
 		}
 		w.Write(respBytes)
@@ -61,12 +70,20 @@ func CommandAndReportResultsHandler(svc service.CommandAndReportResults, logger 
 		}
 		respBytes, err := service.CommandAndReportResultsRequest(svc, mdmReqFromHTTPReq(r), bodyBytes)
 		if err != nil {
-			logger.Info("msg", "command report results", "err", err)
+			logs := []interface{}{"msg", "command report results"}
 			httpStatus := http.StatusInternalServerError
 			var statusErr *service.HTTPStatusError
 			if errors.As(err, &statusErr) {
 				httpStatus = statusErr.Status
+				err = statusErr.Unwrap()
 			}
+			var parseErr *mdm.ParseError
+			if errors.As(err, &parseErr) {
+				logs = append(logs, "content", string(parseErr.Content))
+				err = parseErr.Unwrap()
+			}
+			logs = append(logs, "http_status", httpStatus, "err", err)
+			logger.Info(logs...)
 			http.Error(w, http.StatusText(httpStatus), httpStatus)
 		}
 		w.Write(respBytes)

--- a/http/mdm/mdm.go
+++ b/http/mdm/mdm.go
@@ -2,6 +2,7 @@ package mdm
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -42,13 +43,13 @@ func CheckinHandler(svc service.Checkin, logger log.Logger) http.HandlerFunc {
 			var statusErr *service.HTTPStatusError
 			if errors.As(err, &statusErr) {
 				httpStatus = statusErr.Status
-				err = statusErr.Unwrap()
+				err = fmt.Errorf("HTTP error: %w", statusErr.Unwrap())
 			}
 			// manualy unwrapping the `StatusErr` is not necessary as `errors.As` manually unwraps
 			var parseErr *mdm.ParseError
 			if errors.As(err, &parseErr) {
 				logs = append(logs, "content", string(parseErr.Content))
-				err = statusErr.Unwrap()
+				err = fmt.Errorf("parse error: %w", parseErr.Unwrap())
 			}
 			logs = append(logs, "http_status", httpStatus, "err", err)
 			logger.Info(logs...)
@@ -75,12 +76,12 @@ func CommandAndReportResultsHandler(svc service.CommandAndReportResults, logger 
 			var statusErr *service.HTTPStatusError
 			if errors.As(err, &statusErr) {
 				httpStatus = statusErr.Status
-				err = statusErr.Unwrap()
+				err = fmt.Errorf("HTTP error: %w", statusErr.Unwrap())
 			}
 			var parseErr *mdm.ParseError
 			if errors.As(err, &parseErr) {
 				logs = append(logs, "content", string(parseErr.Content))
-				err = parseErr.Unwrap()
+				err = fmt.Errorf("parse error: %w", parseErr.Unwrap())
 			}
 			logs = append(logs, "http_status", httpStatus, "err", err)
 			logger.Info(logs...)

--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -149,6 +149,9 @@ func (w *checkinUnmarshaller) UnmarshalPlist(f func(interface{}) error) error {
 func DecodeCheckin(rawMessage []byte) (message interface{}, err error) {
 	w := &checkinUnmarshaller{raw: rawMessage}
 	err = plist.Unmarshal(rawMessage, w)
+	if err != nil {
+		err = &ParseError{Err: err, Body: rawMessage}
+	}
 	message = w.message
 	return
 }

--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -150,7 +150,7 @@ func DecodeCheckin(rawMessage []byte) (message interface{}, err error) {
 	w := &checkinUnmarshaller{raw: rawMessage}
 	err = plist.Unmarshal(rawMessage, w)
 	if err != nil {
-		err = &ParseError{Err: err, Body: rawMessage}
+		err = &ParseError{Err: err, Content: rawMessage}
 	}
 	message = w.message
 	return

--- a/mdm/command.go
+++ b/mdm/command.go
@@ -35,7 +35,7 @@ func DecodeCommandResults(rawResults []byte) (results *CommandResults, err error
 	results = new(CommandResults)
 	err = plist.Unmarshal(rawResults, results)
 	if err != nil {
-		return
+		return nil, &ParseError{Err: err, Body: rawResults}
 	}
 	results.Raw = rawResults
 	if results.Status == "" {
@@ -58,7 +58,7 @@ func DecodeCommand(rawCommand []byte) (command *Command, err error) {
 	command = new(Command)
 	err = plist.Unmarshal(rawCommand, command)
 	if err != nil {
-		return
+		return nil, &ParseError{Err: err, Body: rawCommand}
 	}
 	command.Raw = rawCommand
 	if command.CommandUUID == "" || command.Command.RequestType == "" {

--- a/mdm/command.go
+++ b/mdm/command.go
@@ -35,7 +35,7 @@ func DecodeCommandResults(rawResults []byte) (results *CommandResults, err error
 	results = new(CommandResults)
 	err = plist.Unmarshal(rawResults, results)
 	if err != nil {
-		return nil, &ParseError{Err: err, Body: rawResults}
+		return nil, &ParseError{Err: err, Content: rawResults}
 	}
 	results.Raw = rawResults
 	if results.Status == "" {
@@ -58,7 +58,7 @@ func DecodeCommand(rawCommand []byte) (command *Command, err error) {
 	command = new(Command)
 	err = plist.Unmarshal(rawCommand, command)
 	if err != nil {
-		return nil, &ParseError{Err: err, Body: rawCommand}
+		return nil, &ParseError{Err: err, Content: rawCommand}
 	}
 	command.Raw = rawCommand
 	if command.CommandUUID == "" || command.Command.RequestType == "" {

--- a/mdm/mdm.go
+++ b/mdm/mdm.go
@@ -63,7 +63,7 @@ func (r *Request) Clone() *Request {
 
 // ParseError represents a failure to parse an MDM structure (usually Apple Plist)
 type ParseError struct {
-	Err  error
+	Err     error
 	Content []byte
 }
 

--- a/mdm/mdm.go
+++ b/mdm/mdm.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"fmt"
 )
 
 // Enrollment represents the various enrollment-related data sent with requests.
@@ -58,4 +59,17 @@ func (r *Request) Clone() *Request {
 	r2 := new(Request)
 	*r2 = *r
 	return r2
+}
+
+type ParseError struct {
+	Err  error
+	Body []byte
+}
+
+func (e *ParseError) Unwrap() error {
+	return e.Err
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("parse error: %s: raw body: %v", e.Err, string(e.Body))
 }

--- a/mdm/mdm.go
+++ b/mdm/mdm.go
@@ -61,15 +61,18 @@ func (r *Request) Clone() *Request {
 	return r2
 }
 
+// ParseError represents a failure to parse an MDM structure (usually Apple Plist)
 type ParseError struct {
 	Err  error
-	Body []byte
+	Content []byte
 }
 
+// Unwrap returns the underlying error of the ParseError
 func (e *ParseError) Unwrap() error {
 	return e.Err
 }
 
+// Error formats the ParseError as a string
 func (e *ParseError) Error() string {
-	return fmt.Sprintf("parse error: %s: raw body: %v", e.Err, string(e.Body))
+	return fmt.Sprintf("parse error: %v: raw content: %v", e.Err, string(e.Content))
 }


### PR DESCRIPTION
This is useful to debug errors that occur because of bad plists sent by
clients. Usually in this case, one receives a not-very-useful error such
as `HTTP status 400 (Bad Request): <opaque error>`.

 ## Test Plan

1. Patch `mdmb` so that it sends bad checkins
```patch
diff --git a/internal/device/mdm.go b/internal/device/mdm.go
index 33a4c50..cda3d69 100644
--- a/internal/device/mdm.go
+++ b/internal/device/mdm.go
@@ -185,10 +185,7 @@ func (c *MDMClient) connect(client *http.Client, connReq interface{}) error {
                return errors.New("device not enrolled")
        }

-       plistBytes, err := plist.Marshal(connReq)
-       if err != nil {
-               return err
-       }
+       plistBytes := []byte("aoeuaoeuaoeu")
```

2. Run
```
$ mdmb -uuids $uuid devices-connect
```

3. Observe more verbose NanoMDM log:
```
2022/07/21 15:52:43 level=info handler=checkin-command msg=command report results err=HTTP status 400 (Bad Request): decoding command results: parse error: EOF: raw body: aoeuaoeuaoeu
```