### PR TITLE
Export mysql schema variable (and bump go to 1.17)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/micromdm/nanomdm
 
-go 1.15
+go 1.17
 
 require (
 	github.com/RobotsAndPencils/buford v0.14.0
@@ -8,4 +8,9 @@ require (
 	github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5
 	github.com/lib/pq v1.10.6
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
+)
+
+require (
+	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb // indirect
+	golang.org/x/text v0.3.0 // indirect
 )

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -4,6 +4,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 	"errors"
 	"fmt"
 
@@ -12,6 +13,11 @@ import (
 	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 )
+
+// Schema holds the schema for the NanoMDM MySQL storage.
+//
+//go:embed schema.sql
+var Schema string
 
 var ErrNoCert = errors.New("no certificate in MDM Request")
 

--- a/storage/pgsql/postgresql.go
+++ b/storage/pgsql/postgresql.go
@@ -4,6 +4,7 @@ package pgsql
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 	"errors"
 	"fmt"
 
@@ -12,6 +13,11 @@ import (
 	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 )
+
+// Schema holds the schema for the NanoMDM PostgresSQL storage.
+//
+//go:embed schema.sql
+var Schema string
 
 var ErrNoCert = errors.New("no certificate in MDM Request")
 


### PR DESCRIPTION
Hi folks.

I thought it would be a good idea to export the schema as a Go variable. Our ([fleet](https://github.com/fleetdm/fleet)) migration scripts are in Go so this change would come in handy.

And the embed feature was introduced in go 1.17 (hence the change in `go.mod` to upgrade). Am guessing this is a-ok as the related project, MicroMDM, is already in 1.17 ([go.mod](https://github.com/micromdm/micromdm/blob/main/go.mod)).