### PR TITLE
add github action for mysql backend

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,3 +31,51 @@ jobs:
     - name: Format
       if: matrix.platform == 'ubuntu-latest'
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
+
+
+  mysql-integration-test:
+    name: Integration tests for the MySQL backend.
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        platform: [ubuntu-latest]
+        mysql-version: ['8.0']
+    runs-on: ${{ matrix.platform }}
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_RANDOM_ROOT_PASSWORD: yes
+          MYSQL_DATABASE: nanomdm
+          MYSQL_USER: nanomdm
+          MYSQL_PASSWORD: nanomdm
+        ports:
+          - 3800:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+    defaults:
+      run:
+        shell: bash
+    env:
+      MYSQL_PWD: nanomdm
+      PORT: 3800
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: setup go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Verify MySQL connection
+      run: |
+        while ! mysqladmin ping --host=localhost --port=$PORT --protocol=TCP --silent; do
+          sleep 1
+        done
+
+    - name: Set up schema
+      run: |
+        mysql --version
+        mysql --user=nanomdm --host=localhost --port=$PORT --protocol=TCP nanomdm < ./storage/mysql/schema.sql
+
+    - name: Test
+      run: go test -v --tags=integration ./storage/mysql/ -args -dsn "nanomdm:nanomdm@tcp(localhost:$PORT)/nanomdm"


### PR DESCRIPTION
Currently the MySQL backend is not tested, as it requires MySQL server
to run. I have added an integration test to the GitHub workflows which
starts MySQL server in a container, which allows the backend to be
tested. This ignores several "issues" that exist with the tests, such as
the fact that the test is non-idempotent, and fails to run twice.