### PR TITLE
Simplify MySQL delete statement

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,3 +31,51 @@ jobs:
     - name: Format
       if: matrix.platform == 'ubuntu-latest'
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
+
+
+  mysql-integration-test:
+    name: Integration tests for the MySQL backend.
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        platform: [ubuntu-latest]
+        mysql-version: ['8.0']
+    runs-on: ${{ matrix.platform }}
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_RANDOM_ROOT_PASSWORD: yes
+          MYSQL_DATABASE: nanomdm
+          MYSQL_USER: nanomdm
+          MYSQL_PASSWORD: nanomdm
+        ports:
+          - 3800:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+    defaults:
+      run:
+        shell: bash
+    env:
+      MYSQL_PWD: nanomdm
+      PORT: 3800
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: setup go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Verify MySQL connection
+      run: |
+        while ! mysqladmin ping --host=localhost --port=$PORT --protocol=TCP --silent; do
+          sleep 1
+        done
+
+    - name: Set up schema
+      run: |
+        mysql --version
+        mysql --user=nanomdm --host=localhost --port=$PORT --protocol=TCP nanomdm < ./storage/mysql/schema.sql
+
+    - name: Test
+      run: go test -v --tags=integration ./storage/mysql/ -args -dsn "nanomdm:nanomdm@tcp(localhost:$PORT)/nanomdm"


### PR DESCRIPTION
depends on #58 

Currently the delete statement in the MySQL backend is a complicated
multiple-table statement, which is a proprietary MySQL extension to the
SQL language. Furthermore, we have observed issues with this delete
statement deadlocking with itself (when two statements run for the same
command row) due to lock-upgrading issues that occur between the query
and delete steps.

I have changed this DELETE statement to be an ordinary delete, with two
simple select statements (with no joins). These select statements may
not have to be annotated `FOR UPDATE`, but I wanted to err on the side
of avoiding deadlocks.

Testing:
* Observe that MySQL integration tests pass
TODO:
* Make sure that deadlocks no longer occur.