### PR TITLE
MariaDB compatibility

### DIFF
--- a/storage/mysql/certauth.go
+++ b/storage/mysql/certauth.go
@@ -41,9 +41,9 @@ func (s *MySQLStorage) IsCertHashAssociated(r *mdm.Request, hash string) (bool, 
 func (s *MySQLStorage) AssociateCertHash(r *mdm.Request, hash string) error {
 	_, err := s.db.ExecContext(
 		r.Context, `
-INSERT INTO cert_auth_associations (id, sha256) VALUES (?, ?) AS new
+INSERT INTO cert_auth_associations (id, sha256) VALUES (?, ?)
 ON DUPLICATE KEY
-UPDATE sha256 = new.sha256;`,
+UPDATE sha256 = VALUES(sha256);`,
 		r.ID,
 		strings.ToLower(hash),
 	)

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -103,12 +103,12 @@ func (s *MySQLStorage) StoreAuthenticate(r *mdm.Request, msg *mdm.Authenticate) 
 INSERT INTO devices
     (id, identity_cert, serial_number, authenticate, authenticate_at)
 VALUES
-    (?, ?, ?, ?, CURRENT_TIMESTAMP) AS new
+    (?, ?, ?, ?, CURRENT_TIMESTAMP)
 ON DUPLICATE KEY
 UPDATE
-    identity_cert = new.identity_cert,
-    serial_number = new.serial_number,
-    authenticate = new.authenticate,
+    identity_cert = VALUES(identity_cert),
+    serial_number = VALUES(serial_number),
+    authenticate = VALUES(authenticate),
     authenticate_at = CURRENT_TIMESTAMP;`,
 		r.ID, pemCert, nullEmptyString(msg.SerialNumber), msg.Raw,
 	)
@@ -142,13 +142,13 @@ func (s *MySQLStorage) storeUserTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate
 INSERT INTO users
     (id, device_id, user_short_name, user_long_name, token_update, token_update_at)
 VALUES
-    (?, ?, ?, ?, ?, CURRENT_TIMESTAMP) AS new
+    (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 ON DUPLICATE KEY
 UPDATE
-    device_id = new.device_id,
-    user_short_name = new.user_short_name,
-    user_long_name = new.user_long_name,
-    token_update = new.token_update,
+    device_id = VALUES(device_id),
+    user_short_name = VALUES(user_short_name),
+    user_long_name = VALUES(user_long_name),
+    token_update = VALUES(token_update),
     token_update_at = CURRENT_TIMESTAMP;`,
 		r.ID,
 		r.ParentID,
@@ -182,18 +182,18 @@ func (s *MySQLStorage) StoreTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate) er
 INSERT INTO enrollments
 	(id, device_id, user_id, type, topic, push_magic, token_hex, last_seen_at, token_update_tally)
 VALUES
-	(?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, 1) AS new
+	(?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, 1)
 ON DUPLICATE KEY
 UPDATE
-    device_id = new.device_id,
-    user_id = new.user_id,
-    type = new.type,
-    topic = new.topic,
-    push_magic = new.push_magic,
-    token_hex = new.token_hex,
+    device_id = VALUES(device_id),
+    user_id = VALUES(user_id),
+    type = VALUES(type),
+    topic = VALUES(topic),
+    push_magic = VALUES(push_magic),
+    token_hex = VALUES(token_hex),
 	enabled = 1,
 	last_seen_at = CURRENT_TIMESTAMP,
-	enrollments.token_update_tally = enrollments.token_update_tally + 1;`,
+	token_update_tally = token_update_tally + 1;`,
 		r.ID,
 		deviceId,
 		nullEmptyString(userId),
@@ -229,14 +229,14 @@ func (s *MySQLStorage) StoreUserAuthenticate(r *mdm.Request, msg *mdm.UserAuthen
 INSERT INTO users
     (id, device_id, user_short_name, user_long_name, `+colName+`, `+colAtName+`)
 VALUES
-    (?, ?, ?, ?, ?, CURRENT_TIMESTAMP) AS new
+    (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 ON DUPLICATE KEY
 UPDATE
-    device_id = new.device_id,
-    user_short_name = new.user_short_name,
-    user_long_name = new.user_long_name,
-    `+colName+` = new.`+colName+`,
-    `+colAtName+` = new.`+colAtName+`;`,
+    device_id = VALUES(device_id),
+    user_short_name = VALUES(user_short_name),
+    user_long_name = VALUES(user_long_name),
+    `+colName+` = VALUES(`+colName+`),
+    `+colAtName+` = VALUES(`+colAtName+`);`,
 		r.ID,
 		r.ParentID,
 		nullEmptyString(msg.UserShortName),

--- a/storage/mysql/pushcert.go
+++ b/storage/mysql/pushcert.go
@@ -50,12 +50,12 @@ func (s *MySQLStorage) StorePushCert(ctx context.Context, pemCert, pemKey []byte
 INSERT INTO push_certs
     (topic, cert_pem, key_pem, stale_token)
 VALUES
-    (?, ?, ?, 0) AS new
+    (?, ?, ?, 0)
 ON DUPLICATE KEY
 UPDATE
-    cert_pem = new.cert_pem,
-    key_pem = new.key_pem,
-    push_certs.stale_token = push_certs.stale_token + 1;`,
+    cert_pem = VALUES(cert_pem),
+    key_pem = VALUES(key_pem),
+    stale_token = stale_token + 1;`,
 		topic, pemCert, pemKey,
 	)
 	return err

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -125,18 +125,18 @@ func (s *MySQLStorage) StoreCommandReport(r *mdm.Request, result *mdm.CommandRes
 	// not_now_at field. thus it will only represent the first NotNow.
 	if result.Status == "NotNow" {
 		notNowConstants = "CURRENT_TIMESTAMP, 1"
-		notNowBumpTallySQL = `, command_results.not_now_tally = command_results.not_now_tally + 1`
+		notNowBumpTallySQL = `, not_now_tally = not_now_tally + 1`
 	}
 	_, err := s.db.ExecContext(
 		r.Context, `
 INSERT INTO command_results
     (id, command_uuid, status, result, not_now_at, not_now_tally)
 VALUES
-    (?, ?, ?, ?, `+notNowConstants+`) AS new
+    (?, ?, ?, ?, `+notNowConstants+`)
 ON DUPLICATE KEY
 UPDATE
-    status = new.status,
-    result = new.result`+notNowBumpTallySQL+`;`,
+    status = VALUES(status),
+    result = VALUES(result)`+notNowBumpTallySQL+`;`,
 		r.ID,
 		result.CommandUUID,
 		result.Status,


### PR DESCRIPTION
Several Linux distributions have replaced MySQL in their repositories with MariaDB, a fork of MySQL. MariaDB does not support `INSERT ... AS`, so this PR rewrites the existing use of `INSERT ... AS` to a form that works in both MySQL and MariaDB.