### PR TITLE
new push provider: nanopush

### DIFF
--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/micromdm/nanomdm/http/authproxy"
 	httpmdm "github.com/micromdm/nanomdm/http/mdm"
 	"github.com/micromdm/nanomdm/log/stdlogfmt"
-	"github.com/micromdm/nanomdm/push/buford"
+	"github.com/micromdm/nanomdm/push/nanopush"
 	pushsvc "github.com/micromdm/nanomdm/push/service"
 	"github.com/micromdm/nanomdm/service"
 	"github.com/micromdm/nanomdm/service/certauth"
@@ -191,7 +191,7 @@ func main() {
 		const apiUsername = "nanomdm"
 
 		// create our push provider and push service
-		pushProviderFactory := buford.NewPushProviderFactory()
+		pushProviderFactory := nanopush.NewFactory()
 		pushService := pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, logger.With("service", "push"))
 
 		// register API handler for push cert storage/upload.

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,7 @@ require (
 	github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5
 	github.com/lib/pq v1.10.9
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
+	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb
 )
 
-require (
-	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb // indirect
-	golang.org/x/text v0.3.0 // indirect
-)
+require golang.org/x/text v0.3.0 // indirect

--- a/push/buford/buford.go
+++ b/push/buford/buford.go
@@ -3,6 +3,7 @@
 package buford
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"net/http"
@@ -125,7 +126,7 @@ func (c *bufordPushProvider) pushMulti(pushInfos []*mdm.Push) map[string]*push.R
 }
 
 // Push sends 'raw' MDM APNs push notifications to service in c.
-func (c *bufordPushProvider) Push(pushInfos []*mdm.Push) (map[string]*push.Response, error) {
+func (c *bufordPushProvider) Push(_ context.Context, pushInfos []*mdm.Push) (map[string]*push.Response, error) {
 	if len(pushInfos) < 1 {
 		return nil, errors.New("no push data provided")
 	}

--- a/push/nanopush/nanopush.go
+++ b/push/nanopush/nanopush.go
@@ -1,0 +1,136 @@
+// Pacakge nanopush implements an Apple APNs HTTP/2 service for MDM.
+// It implements the PushProvider and PushProviderFactory interfaces.
+package nanopush
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/push"
+	"golang.org/x/net/http2"
+)
+
+// NewClient describes a callback for setting up an HTTP client for Push notifications.
+type NewClient func(*tls.Certificate) (*http.Client, error)
+
+// ClientWithCert configures an mTLS client cert on the HTTP client.
+func ClientWithCert(client *http.Client, cert *tls.Certificate) (*http.Client, error) {
+	if cert == nil {
+		return client, errors.New("no cert provided")
+	}
+	if client == nil {
+		clone := *http.DefaultClient
+		client = &clone
+	}
+	config := &tls.Config{
+		Certificates: []tls.Certificate{*cert},
+	}
+	config.BuildNameToCertificate()
+	if client.Transport == nil {
+		client.Transport = &http.Transport{}
+	}
+	transport := client.Transport.(*http.Transport)
+	transport.TLSClientConfig = config
+	// force HTTP/2
+	err := http2.ConfigureTransport(transport)
+	return client, err
+}
+
+func defaultNewClient(cert *tls.Certificate) (*http.Client, error) {
+	return ClientWithCert(nil, cert)
+}
+
+// Factory instantiates new PushProviders.
+type Factory struct {
+	newClient  NewClient
+	expiration time.Duration
+}
+
+type Option func(*Factory)
+
+// WithNewClient sets a callback to setup an HTTP client for each
+// new Push provider.
+func WithNewClient(newClient NewClient) Option {
+	return func(f *Factory) {
+		f.newClient = newClient
+	}
+}
+
+// WithExpiration sets the APNs expiration time for the push notifications.
+func WithExpiration(expiration time.Duration) Option {
+	return func(f *Factory) {
+		f.expiration = expiration
+	}
+}
+
+// NewFactory creates a new Factory.
+func NewFactory(opts ...Option) *Factory {
+	f := &Factory{
+		newClient: defaultNewClient,
+	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
+}
+
+// NewPushProvider generates a new PushProvider given a tls keypair.
+func (f *Factory) NewPushProvider(cert *tls.Certificate) (push.PushProvider, error) {
+	p := &Provider{expiration: f.expiration}
+	var err error
+	p.client, err = f.newClient(cert)
+	return p, err
+}
+
+type Provider struct {
+	client     *http.Client
+	expiration time.Duration
+}
+
+func (p *Provider) do1(ctx context.Context, pushInfo *mdm.Push) *push.Response {
+	payload := []byte(`{"mdm":"` + pushInfo.PushMagic + `"}`)
+	url := fmt.Sprintf("%s/3/device/%s", "https://api.push.apple.com", pushInfo.Token.String())
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return &push.Response{Err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p.expiration > 0 {
+		exp := time.Now().Add(p.expiration)
+		req.Header.Set("apns-expiration", strconv.FormatInt(exp.Unix(), 10))
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return &push.Response{Err: err}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		// TODO: better parsing!
+		bodyR, _ := io.ReadAll(resp.Body)
+		return &push.Response{Err: fmt.Errorf("invalid status code: %d: %s", resp.StatusCode, string(bodyR))}
+	}
+	return &push.Response{Id: resp.Header.Get("apns-id")}
+
+}
+
+func (p *Provider) Push(pushInfos []*mdm.Push) (map[string]*push.Response, error) {
+	if len(pushInfos) < 1 {
+		return nil, errors.New("no push data provided")
+	}
+	ret := make(map[string]*push.Response)
+	for _, pushInfo := range pushInfos {
+		if pushInfo == nil {
+			continue
+		}
+		ret[pushInfo.Token.String()] = p.do1(context.TODO(), pushInfo)
+	}
+	return ret, nil
+}

--- a/push/nanopush/provider.go
+++ b/push/nanopush/provider.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
@@ -72,9 +71,6 @@ func (p *Provider) do(ctx context.Context, pushInfo *mdm.Push) *push.Response {
 	jsonPayload := []byte(`{"mdm":"` + pushInfo.PushMagic + `"}`)
 
 	url := p.baseURL + "/3/device/" + pushInfo.Token.String()
-	if rand.Intn(2) == 0 {
-		url += "x"
-	}
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonPayload))
 
 	if err != nil {

--- a/push/nanopush/provider.go
+++ b/push/nanopush/provider.go
@@ -1,0 +1,185 @@
+package nanopush
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/push"
+	"golang.org/x/net/http2"
+)
+
+// Doer is ostensibly an *http.Client
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+const (
+	Development     = "https://api.development.push.apple.com"
+	Development2197 = "https://api.development.push.apple.com:2197"
+	Production      = "https://api.push.apple.com"
+	Production2197  = "https://api.push.apple.com:2197"
+)
+
+// Provider sends pushes to Apple's APNs servers.
+type Provider struct {
+	client     Doer
+	expiration time.Duration
+	workers    int
+	baseURL    string
+}
+
+// JSONPushError is a JSON error returned from the APNs service.
+type JSONPushError struct {
+	Reason    string `json:"reason"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+func (e *JSONPushError) Error() string {
+	s := "APNs push error"
+	if e == nil {
+		return s + ": nil"
+	}
+	if e.Reason != "" {
+		s += ": " + e.Reason
+	}
+	if e.Timestamp > 0 {
+		s += ": timestamp " + strconv.FormatInt(e.Timestamp, 10)
+	}
+	return s
+}
+
+func newError(body io.Reader, statusCode int) error {
+	var err error = new(JSONPushError)
+	if decodeErr := json.NewDecoder(body).Decode(err); decodeErr != nil {
+		err = fmt.Errorf("decoding JSON push error: %w", decodeErr)
+	}
+	return fmt.Errorf("push HTTP status: %d: %w", statusCode, err)
+}
+
+// do performs the HTTP push request
+func (p *Provider) do(ctx context.Context, pushInfo *mdm.Push) *push.Response {
+	jsonPayload := []byte(`{"mdm":"` + pushInfo.PushMagic + `"}`)
+
+	url := p.baseURL + "/3/device/" + pushInfo.Token.String()
+	if rand.Intn(2) == 0 {
+		url += "x"
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonPayload))
+
+	if err != nil {
+		return &push.Response{Err: err}
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if p.expiration > 0 {
+		exp := time.Now().Add(p.expiration)
+		req.Header.Set("apns-expiration", strconv.FormatInt(exp.Unix(), 10))
+	}
+	r, err := p.client.Do(req)
+	var goAwayErr http2.GoAwayError
+	if errors.As(err, &goAwayErr) {
+		body := strings.NewReader(goAwayErr.DebugData)
+		return &push.Response{Err: newError(body, r.StatusCode)}
+	} else if err != nil {
+		return &push.Response{Err: err}
+	}
+
+	defer r.Body.Close()
+	response := &push.Response{Id: r.Header.Get("apns-id")}
+	if r.StatusCode != http.StatusOK {
+		response.Err = newError(r.Body, r.StatusCode)
+	}
+	return response
+}
+
+// pushSerial performs APNs pushes serially.
+func (p *Provider) pushSerial(ctx context.Context, pushInfos []*mdm.Push) (map[string]*push.Response, error) {
+	ret := make(map[string]*push.Response)
+	for _, pushInfo := range pushInfos {
+		if pushInfo == nil {
+			continue
+		}
+		ret[pushInfo.Token.String()] = p.do(ctx, pushInfo)
+	}
+	return ret, nil
+}
+
+// pushConcurrent performs APNs pushes concurrently.
+// It spawns worker goroutines and feeds them from the list of pushInfos.
+func (p *Provider) pushConcurrent(ctx context.Context, pushInfos []*mdm.Push) (map[string]*push.Response, error) {
+	// don't start more workers than we have pushes to send
+	workers := p.workers
+	if len(pushInfos) > workers {
+		workers = len(pushInfos)
+	}
+
+	// response associates push.Response with token
+	type response struct {
+		token    string
+		response *push.Response
+	}
+
+	jobs := make(chan *mdm.Push)
+	results := make(chan response)
+	var wg sync.WaitGroup
+
+	// start our workers
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for pushInfo := range jobs {
+				results <- response{
+					token:    pushInfo.Token.String(),
+					response: p.do(ctx, pushInfo),
+				}
+			}
+		}()
+	}
+
+	// start the "feeder" (queue source)
+	go func() {
+		for _, pushInfo := range pushInfos {
+			jobs <- pushInfo
+		}
+		close(jobs)
+	}()
+
+	// watch for our workers finishing (they should after feeding is done)
+	// stop the collector when the workers have finished.
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// collect our results
+	ret := make(map[string]*push.Response)
+	for r := range results {
+		ret[r.token] = r.response
+	}
+
+	return ret, nil
+}
+
+// Push sends APNs pushes to MDM enrollments.
+func (p *Provider) Push(pushInfos []*mdm.Push) (map[string]*push.Response, error) {
+	ctx := context.TODO()
+	if len(pushInfos) < 1 {
+		return nil, errors.New("no push data provided")
+	} else if len(pushInfos) == 1 {
+		return p.pushSerial(ctx, pushInfos)
+	} else {
+		return p.pushConcurrent(ctx, pushInfos)
+	}
+}

--- a/push/nanopush/provider.go
+++ b/push/nanopush/provider.go
@@ -173,8 +173,7 @@ func (p *Provider) pushConcurrent(ctx context.Context, pushInfos []*mdm.Push) (m
 }
 
 // Push sends APNs pushes to MDM enrollments.
-func (p *Provider) Push(pushInfos []*mdm.Push) (map[string]*push.Response, error) {
-	ctx := context.TODO()
+func (p *Provider) Push(ctx context.Context, pushInfos []*mdm.Push) (map[string]*push.Response, error) {
 	if len(pushInfos) < 1 {
 		return nil, errors.New("no push data provided")
 	} else if len(pushInfos) == 1 {

--- a/push/nanopush/provider_test.go
+++ b/push/nanopush/provider_test.go
@@ -1,0 +1,65 @@
+package nanopush
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/micromdm/nanomdm/mdm"
+)
+
+func TestPush(t *testing.T) {
+	deviceToken := "c2732227a1d8021cfaf781d71fb2f908c61f5861079a00954a5453f1d0281433"
+	pushMagic := "47250C9C-1B37-4381-98A9-0B8315A441C7"
+	topic := "com.example.apns-topic"
+	payload := []byte(`{"mdm":"` + pushMagic + `"}`)
+	apnsID := "922D9F1F-B82E-B337-EDC9-DB4FC8527676"
+
+	handler := http.NewServeMux()
+	server := httptest.NewServer(handler)
+
+	handler.HandleFunc("/3/device/", func(w http.ResponseWriter, r *http.Request) {
+		expectURL := fmt.Sprintf("/3/device/%s", deviceToken)
+		if have, want := r.URL.String(), expectURL; have != want {
+			t.Errorf("url: have %q, want %q", have, want)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if have, want := body, payload; !bytes.Equal(have, want) {
+			t.Errorf("body: have %q, want %q", string(have), string(want))
+		}
+
+		w.Header().Set("apns-id", apnsID)
+	})
+
+	prov := &Provider{
+		baseURL: server.URL,
+		client:  http.DefaultClient,
+	}
+
+	pushInfo := &mdm.Push{
+		PushMagic: pushMagic,
+		Topic:     topic,
+	}
+	pushInfo.SetTokenString(deviceToken)
+
+	resp, err := prov.Push([]*mdm.Push{pushInfo})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, ok := resp[deviceToken]
+	if !ok || result == nil {
+		t.Fatal("device token not found (or is nil) in response")
+	}
+
+	if have, want := result.Id, apnsID; have != want {
+		t.Errorf("url: have %q, want %q", have, want)
+	}
+}

--- a/push/nanopush/provider_test.go
+++ b/push/nanopush/provider_test.go
@@ -2,6 +2,7 @@ package nanopush
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -49,7 +50,7 @@ func TestPush(t *testing.T) {
 	}
 	pushInfo.SetTokenString(deviceToken)
 
-	resp, err := prov.Push([]*mdm.Push{pushInfo})
+	resp, err := prov.Push(context.Background(), []*mdm.Push{pushInfo})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/push/nanopush/provider_test.go
+++ b/push/nanopush/provider_test.go
@@ -21,6 +21,7 @@ func TestPush(t *testing.T) {
 
 	handler := http.NewServeMux()
 	server := httptest.NewServer(handler)
+	defer server.Close()
 
 	handler.HandleFunc("/3/device/", func(w http.ResponseWriter, r *http.Request) {
 		expectURL := fmt.Sprintf("/3/device/%s", deviceToken)

--- a/push/push.go
+++ b/push/push.go
@@ -24,7 +24,7 @@ type Pusher interface {
 // The non-error return type maps the string value of the push token
 // (that is, the hex encoding of the bytes) to a pointer to a Response.
 type PushProvider interface {
-	Push([]*mdm.Push) (map[string]*Response, error)
+	Push(context.Context, []*mdm.Push) (map[string]*Response, error)
 }
 
 // PushProviderFactory generates a new PushProvider given a tls keypair

--- a/push/service/service.go
+++ b/push/service/service.go
@@ -102,7 +102,7 @@ func (s *PushService) pushSingle(ctx context.Context, pushInfo *mdm.Push) (map[s
 	if err != nil {
 		return nil, err
 	}
-	return prov.Push([]*mdm.Push{pushInfo})
+	return prov.Push(ctx, []*mdm.Push{pushInfo})
 }
 
 // pushMulti sends pushes to (potentially) multiple push providers
@@ -128,7 +128,7 @@ func (s *PushService) pushMulti(ctx context.Context, pushInfos []*mdm.Push) (map
 		}
 		topicPushCt += 1
 		go func(prov push.PushProvider, pushInfos []*mdm.Push, feedback chan<- pushFeedback, topic string) {
-			resp, err := prov.Push(pushInfos)
+			resp, err := prov.Push(ctx, pushInfos)
 			feedback <- pushFeedback{
 				Responses: resp,
 				Err:       err,

--- a/push/service/service.go
+++ b/push/service/service.go
@@ -86,6 +86,7 @@ func (s *PushService) getProvider(ctx context.Context, topic string) (push.PushP
 type pushFeedback struct {
 	Responses map[string]*push.Response
 	Err       error
+	Topic     string
 }
 
 var ErrIdNotFound = errors.New("push data missing for id")
@@ -126,23 +127,24 @@ func (s *PushService) pushMulti(ctx context.Context, pushInfos []*mdm.Push) (map
 			continue
 		}
 		topicPushCt += 1
-		go func(prov push.PushProvider, pushInfos []*mdm.Push, feedback chan<- pushFeedback) {
+		go func(prov push.PushProvider, pushInfos []*mdm.Push, feedback chan<- pushFeedback, topic string) {
 			resp, err := prov.Push(pushInfos)
 			feedback <- pushFeedback{
 				Responses: resp,
 				Err:       err,
+				Topic:     topic,
 			}
-		}(prov, pushInfos, feedbackChan)
+		}(prov, pushInfos, feedbackChan, topic)
 	}
 	responses := make(map[string]*push.Response)
 	for i := 0; i < topicPushCt; i++ {
 		feedback := <-feedbackChan
 		// merge feedback responses into main responses map
 		for token, pushResp := range feedback.Responses {
-			if finalErr == nil && pushResp.Err != nil {
-				finalErr = pushResp.Err
-			}
 			responses[token] = pushResp
+		}
+		if finalErr == nil && feedback.Err != nil {
+			finalErr = fmt.Errorf("topic %s: %w", feedback.Topic, feedback.Err)
 		}
 	}
 	close(feedbackChan)
@@ -184,14 +186,8 @@ func (s *PushService) Push(ctx context.Context, ids []string) (map[string]*push.
 		// some environments may heavily utilize individual pushes.
 		// this justifies the special case and optimizes for it.
 		tokenToResponse, err = s.pushSingle(ctx, pushInfos[0])
-		if err != nil {
-			return nil, err
-		}
 	} else if len(pushInfos) > 1 {
 		tokenToResponse, err = s.pushMulti(ctx, pushInfos)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// re-associate token responses with ids
@@ -206,5 +202,5 @@ func (s *PushService) Push(ctx context.Context, ids []string) (map[string]*push.
 		idToResponse[id] = resp
 	}
 
-	return idToResponse, nil
+	return idToResponse, err
 }


### PR DESCRIPTION
The push library we've used forever, [buford](https://github.com/RobotsAndPencils/buford), was archived by the maintainers in early June of 2023. I quickly looked at a couple other libraries:

* https://github.com/sideshow/apns2 - a popular library. seem a bit large/kitchen-sink-ey, but not bad.
* https://github.com/edganiukov/apns - nice and tiny, but too app-focused (no custom payloads), not sure the correct non-JWT http2 forcing is done, either.

However, because our use of APNs for MDM purposes is limited in scope and we don't need the bells and whistles of an app-focused APNs library I took a stab at implementing just native HTTP/2 connections ourselves. There's not a whole lot of magic to make it work.

This PR plugs right into the `PushProvider` and `PushProviderFactory` interfaces and is enabled with a 1-line change in `main()`.

It works as is:

```sh
$ curl -u nanomdm:$APIKEY "[::1]:9000/v1/push/AAABBB,CCCDDD"
{
	"status": {
		"AAABBB": {
			"push_result": "40B2A5DE-4B8A-4A6A-BC0E-BA4279F9F77F"
		},
		"CCCDDD": {
			"push_result": "6F089EFA-0FAD-D9AF-D742-5D48DA0E5BE9"
		}
	}
}
```

In addition to general tidy and docs I want to take a look at parallelization. The existing buford integration makes use of buford's [Queue](https://pkg.go.dev/github.com/RobotsAndPencils/buford@v0.14.0/push#Queue) system when there is more than one notification. This spawns workers to try and speed up delivery. I'd like to think more on whether we should have a worker system, too, to quickly send notifications. I know that for our org, as DDM looms, we'll have much more multi-command/push situations coming up. Though, I want to think through how parallel the HTTP library itself is to see if this is necessary, because we issue all requests to a single `http.Client{}`.