### PR TITLE
authproxy: MDM device identity authenticated HTTP requests

### DIFF
--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -169,6 +169,7 @@ func main() {
 			if err != nil {
 				stdlog.Fatal(err)
 			}
+			authProxyHandler = http.StripPrefix(endpointAuthProxy, authProxyHandler)
 			authProxyHandler = httpmdm.CertWithEnrollmentIDMiddleware(authProxyHandler, certauth.HashCert, mdmStorage, true, logger.With("handler", "with-enrollment-id"))
 			authProxyHandler = httpmdm.CertVerifyMiddleware(authProxyHandler, verifier, logger.With("handler", "cert-verify"))
 			if *flCertHeader != "" {

--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -44,6 +44,11 @@ const (
 	endpointAPIVersion   = "/version"
 )
 
+const (
+	EnrollmentIDHeader = "X-Enrollment-ID"
+	TraceIDHeader      = "X-Trace-ID"
+)
+
 func main() {
 	cliStorage := cli.NewStorage()
 	flag.Var(&cliStorage.Storage, "storage", "name of storage backend")
@@ -166,7 +171,11 @@ func main() {
 
 		if *flAuthProxy != "" {
 			var authProxyHandler http.Handler
-			authProxyHandler, err = authproxy.New(*flAuthProxy, logger.With("handler", "authproxy"))
+			authProxyHandler, err = authproxy.New(*flAuthProxy,
+				authproxy.WithLogger(logger.With("handler", "authproxy")),
+				authproxy.WithHeaderFunc(EnrollmentIDHeader, httpmdm.GetEnrollmentID),
+				authproxy.WithHeaderFunc(TraceIDHeader, mdmhttp.GetTraceID),
+			)
 			if err != nil {
 				stdlog.Fatal(err)
 			}

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -327,6 +327,8 @@ If the `-auth-proxy-url` flag is provided then URLs that begin with `/authproxy/
 
 This feature is ostensibly to support Declarative Device Management and in particular the ability for some "Asset" declarations to use "MDM" authentication for their content. For example the `com.apple.asset.data` declaration supports an [Authentication key](https://github.com/apple/device-management/blob/2bb1726786047949b5b1aa923be33b9ba0f83e37/declarative/declarations/assets/data.yaml#L40-L54) for configuring this ability.
 
+As an example example if this feature is enabled and a request comes to the server as `/authproxy/foo/bar` and the `-auth-proxy-url` was set to, say, `http://[::1]:9008` then NanoMDM will reverse proxy this URL to `http://[::1]:9008/foo/bar`. An HTP 502 Bad Gateway response is sent back to the client for any issues proxying.
+
 # Enrollment Migration (nano2nano)
 
 The `nano2nano` tool extracts migration enrollment data from a given storage backend and sends it to a NanoMDM migration endpoint. In this way you can effectively migrate between database backends. For example if you started with a `file` backend you could migrate to a `mysql` backend and vice versa. Note that MDM servers must have *exactly* the same server URL for migrations to operate.

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -163,6 +163,12 @@ Print version and exit.
 
 NanoMDM supports a MicroMDM-compatible [webhook callback](https://github.com/micromdm/micromdm/blob/main/docs/user-guide/api-and-webhooks.md) option. This switch turns on the webhook and specifies the URL.
 
+### -auth-proxy-url string
+
+* Reverse proxy URL target for MDM-authenticated HTTP requests
+
+Enables the authentication proxy and reverse proxies HTTP requests from the server's `/authproxy/` endpoint to this URL if the client provides the device's enrollment authentication. See below for more information.
+
 ## HTTP endpoints & APIs
 
 ### MDM
@@ -312,6 +318,14 @@ The migration endpoint (as talked about above under the `-migration` switch) is 
 * Endpoint: `/version`
 
 Returns a JSON response with the version of the running NanoMDM server.
+
+### Authentication Proxy
+
+* Endpoint: `/authproxy/`
+
+If the `-auth-proxy-url` flag is provided then URLs that begin with `/authproxy/` will be reverse-proxied to the given target URL. Importantly this endpoint will authenticate the incoming request in the same way as other MDM endpoints (i.e. Check-In or Command Report and Response) — including whether we're using TLS client configuration or not (the `-cert-header` flag). Put together this allow you to have MDM-authenticated content retrieval.
+
+This feature is ostensibly to support Declarative Device Management and in particular the ability for some "Asset" declarations to use "MDM" authentication for their content. For example the `com.apple.asset.data` declaration supports an [Authentication key](https://github.com/apple/device-management/blob/2bb1726786047949b5b1aa923be33b9ba0f83e37/declarative/declarations/assets/data.yaml#L40-L54) for configuring this ability.
 
 # Enrollment Migration (nano2nano)
 

--- a/http/authproxy/authproxy.go
+++ b/http/authproxy/authproxy.go
@@ -1,0 +1,51 @@
+// Package authproxy is a simple reverse proxy for Apple MDM clients.
+package authproxy
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	mdmhttp "github.com/micromdm/nanomdm/http"
+	httpmdm "github.com/micromdm/nanomdm/http/mdm"
+	"github.com/micromdm/nanomdm/log"
+	"github.com/micromdm/nanomdm/log/ctxlog"
+)
+
+const (
+	EnrollmentIDHeader = "X-Enrollment-ID"
+	TraceIDHeader      = "X-Trace-ID"
+)
+
+// New creates a new NanoMDM enrollment authenticating reverse proxy.
+// This reverse proxy is mostly the standard httputil proxy. It depends
+// on middleware HTTP handlers to enforce authentication and set the
+// context value for the enrollment ID.
+func New(dest string, logger log.Logger) (*httputil.ReverseProxy, error) {
+	target, err := url.Parse(dest)
+	if err != nil {
+		return nil, err
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		ctxlog.Logger(r.Context(), logger).Info("err", err)
+		// use the same error as the standrad reverse proxy
+		w.WriteHeader(http.StatusBadGateway)
+	}
+	dir := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		dir(req)
+		req.Host = target.Host
+		// save the effort of forwarding this huge header
+		req.Header.Del("Mdm-Signature")
+		if id := httpmdm.GetEnrollmentID(req.Context()); id != "" {
+			req.Header.Set(EnrollmentIDHeader, id)
+		}
+		// TODO: this couples us to our specific idea of trace logging
+		// Perhaps have an optional config for header specificaiton?
+		if id := mdmhttp.GetTraceID(req.Context()); id != "" {
+			req.Header.Set(TraceIDHeader, id)
+		}
+	}
+	return proxy, nil
+}

--- a/http/authproxy/authproxy.go
+++ b/http/authproxy/authproxy.go
@@ -2,33 +2,68 @@
 package authproxy
 
 import (
+	"context"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 
-	mdmhttp "github.com/micromdm/nanomdm/http"
-	httpmdm "github.com/micromdm/nanomdm/http/mdm"
 	"github.com/micromdm/nanomdm/log"
 	"github.com/micromdm/nanomdm/log/ctxlog"
 )
 
-const (
-	EnrollmentIDHeader = "X-Enrollment-ID"
-	TraceIDHeader      = "X-Trace-ID"
-)
+// HeaderFunc takes an HTTP request and returns a string value.
+// Ostensibly to be set in a header on the proxy target.
+type HeaderFunc func(context.Context) string
+
+type config struct {
+	logger      log.Logger
+	fwdSig      bool
+	headerFuncs map[string]HeaderFunc
+}
+
+type Option func(*config)
+
+// WithLogger sets a logger for error reporting.
+func WithLogger(logger log.Logger) Option {
+	return func(c *config) {
+		c.logger = logger
+	}
+}
+
+// WithHeaderFunc configures fn to be called and added as an HTTP header to the proxy target request.
+func WithHeaderFunc(header string, fn HeaderFunc) Option {
+	return func(c *config) {
+		c.headerFuncs[header] = fn
+	}
+}
+
+// WithForwardMDMSignature forwards the MDM-Signature header onto the proxy destination.
+// This option is off by default because the header adds about two kilobytes to the request.
+func WithForwardMDMSignature() Option {
+	return func(c *config) {
+		c.fwdSig = true
+	}
+}
 
 // New creates a new NanoMDM enrollment authenticating reverse proxy.
 // This reverse proxy is mostly the standard httputil proxy. It depends
 // on middleware HTTP handlers to enforce authentication and set the
 // context value for the enrollment ID.
-func New(dest string, logger log.Logger) (*httputil.ReverseProxy, error) {
+func New(dest string, opts ...Option) (*httputil.ReverseProxy, error) {
+	config := &config{
+		logger:      log.NopLogger,
+		headerFuncs: make(map[string]HeaderFunc),
+	}
+	for _, opt := range opts {
+		opt(config)
+	}
 	target, err := url.Parse(dest)
 	if err != nil {
 		return nil, err
 	}
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		ctxlog.Logger(r.Context(), logger).Info("err", err)
+		ctxlog.Logger(r.Context(), config.logger).Info("err", err)
 		// use the same error as the standrad reverse proxy
 		w.WriteHeader(http.StatusBadGateway)
 	}
@@ -36,15 +71,18 @@ func New(dest string, logger log.Logger) (*httputil.ReverseProxy, error) {
 	proxy.Director = func(req *http.Request) {
 		dir(req)
 		req.Host = target.Host
-		// save the effort of forwarding this huge header
-		req.Header.Del("Mdm-Signature")
-		if id := httpmdm.GetEnrollmentID(req.Context()); id != "" {
-			req.Header.Set(EnrollmentIDHeader, id)
+		if !config.fwdSig {
+			// save the effort of forwarding this huge header
+			req.Header.Del("Mdm-Signature")
 		}
-		// TODO: this couples us to our specific idea of trace logging
-		// Perhaps have an optional config for header specificaiton?
-		if id := mdmhttp.GetTraceID(req.Context()); id != "" {
-			req.Header.Set(TraceIDHeader, id)
+		// set any headers we want to forward.
+		for k, fn := range config.headerFuncs {
+			if k == "" || fn == nil {
+				continue
+			}
+			if v := fn(req.Context()); v != "" {
+				req.Header.Set(k, v)
+			}
 		}
 	}
 	return proxy, nil

--- a/http/http.go
+++ b/http/http.go
@@ -51,6 +51,12 @@ func VersionHandler(version string) http.HandlerFunc {
 
 type ctxKeyTraceID struct{}
 
+// GetTraceID returns the trace ID from ctx.
+func GetTraceID(ctx context.Context) string {
+	id, _ := ctx.Value(ctxKeyTraceID{}).(string)
+	return id
+}
+
 // TraceLoggingMiddleware sets up a trace ID in the request context and
 // logs HTTP requests.
 func TraceLoggingMiddleware(next http.Handler, logger log.Logger, traceID func(*http.Request) string) http.HandlerFunc {

--- a/http/mdm/mdm_cert.go
+++ b/http/mdm/mdm_cert.go
@@ -168,7 +168,7 @@ func CertWithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store stor
 				return
 			}
 		}
-		mr, err := store.EnrollmentFromHash(r.Context(), hasher(cert))
+		id, err := store.EnrollmentFromHash(r.Context(), hasher(cert))
 		if err != nil {
 			ctxlog.Logger(r.Context(), logger).Info(
 				"msg", "retreiving enrollment from hash",
@@ -177,7 +177,7 @@ func CertWithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store stor
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		if mr == nil || mr.ID == "" {
+		if id == "" {
 			if enforce {
 				ctxlog.Logger(r.Context(), logger).Info(
 					"err", "missing enrollment id",
@@ -192,7 +192,7 @@ func CertWithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store stor
 				return
 			}
 		}
-		ctx := context.WithValue(r.Context(), contextEnrollmentID, mr.ID)
+		ctx := context.WithValue(r.Context(), contextEnrollmentID, id)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}
 }

--- a/http/mdm/mdm_cert.go
+++ b/http/mdm/mdm_cert.go
@@ -148,6 +148,9 @@ type HashFn func(*x509.Certificate) string
 // enforce is true. This way next is able to use the existence of the ID on
 // the context to make its own decisions.
 func CertWithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store storage.CertAuthRetriever, enforce bool, logger log.Logger) http.HandlerFunc {
+	if store == nil || hasher == nil {
+		panic("store and hasher must not be nil")
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		cert := GetCert(r.Context())
 		if cert == nil {
@@ -164,9 +167,6 @@ func CertWithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store stor
 				next.ServeHTTP(w, r)
 				return
 			}
-		}
-		if store == nil || hasher == nil {
-			panic("store nor hasher must not be nil")
 		}
 		mr, err := store.EnrollmentFromHash(r.Context(), hasher(cert))
 		if err != nil {

--- a/http/mdm/mdm_cert.go
+++ b/http/mdm/mdm_cert.go
@@ -158,6 +158,8 @@ func CertWithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store stor
 				ctxlog.Logger(r.Context(), logger).Info(
 					"err", "missing certificate",
 				)
+				// we cannot send a 401 to the client as it has MDM protocol semantics
+				// i.e. the device may unenroll
 				http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusBadRequest)
 				return
 			} else {

--- a/http/mdm/mdm_cert.go
+++ b/http/mdm/mdm_cert.go
@@ -10,9 +10,12 @@ import (
 	mdmhttp "github.com/micromdm/nanomdm/http"
 	"github.com/micromdm/nanomdm/log"
 	"github.com/micromdm/nanomdm/log/ctxlog"
+	"github.com/micromdm/nanomdm/storage"
 )
 
 type contextKeyCert struct{}
+
+var contextEnrollmentID struct{}
 
 // CertExtractPEMHeaderMiddleware extracts the MDM enrollment identity
 // certificate from the request into the HTTP request context. It looks
@@ -126,5 +129,70 @@ func CertVerifyMiddleware(next http.Handler, verifier CertVerifier, logger log.L
 			return
 		}
 		next.ServeHTTP(w, r)
+	}
+}
+
+// GetEnrollmentID retrieves the MDM enrollment ID from ctx.
+func GetEnrollmentID(ctx context.Context) string {
+	id, _ := ctx.Value(contextEnrollmentID).(string)
+	return id
+}
+
+type HashFn func(*x509.Certificate) string
+
+// WithEnrollmentIDMiddleware tries to associate the enrollment ID to the request context.
+// It does this by looking up the certificate on the context, hashing it with
+// hasher, looking up the hash in storage, and setting the ID on the context.
+//
+// The next handler will be called even if cert or ID is not found unless
+// enforce is true. This way next is able to use the existence of the ID on
+// the context to make its own decisions.
+func WithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store storage.CertAuthRetriever, enforce bool, logger log.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cert := GetCert(r.Context())
+		if cert == nil {
+			if enforce {
+				ctxlog.Logger(r.Context(), logger).Info(
+					"err", "missing certificate",
+				)
+				http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusBadRequest)
+				return
+			} else {
+				ctxlog.Logger(r.Context(), logger).Debug(
+					"msg", "missing certificate",
+				)
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+		if store == nil || hasher == nil {
+			panic("store nor hasher must not be nil")
+		}
+		mr, err := store.EnrollmentFromHash(r.Context(), hasher(cert))
+		if err != nil {
+			ctxlog.Logger(r.Context(), logger).Info(
+				"msg", "retreiving enrollment from hash",
+				"err", err,
+			)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		if mr == nil || mr.ID == "" {
+			if enforce {
+				ctxlog.Logger(r.Context(), logger).Info(
+					"err", "missing enrollment id",
+				)
+				http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusBadRequest)
+				return
+			} else {
+				ctxlog.Logger(r.Context(), logger).Debug(
+					"msg", "missing enrollment id",
+				)
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+		ctx := context.WithValue(r.Context(), contextEnrollmentID, mr.ID)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	}
 }

--- a/http/mdm/mdm_cert.go
+++ b/http/mdm/mdm_cert.go
@@ -140,14 +140,14 @@ func GetEnrollmentID(ctx context.Context) string {
 
 type HashFn func(*x509.Certificate) string
 
-// WithEnrollmentIDMiddleware tries to associate the enrollment ID to the request context.
+// CertWithEnrollmentIDMiddleware tries to associate the enrollment ID to the request context.
 // It does this by looking up the certificate on the context, hashing it with
 // hasher, looking up the hash in storage, and setting the ID on the context.
 //
 // The next handler will be called even if cert or ID is not found unless
 // enforce is true. This way next is able to use the existence of the ID on
 // the context to make its own decisions.
-func WithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store storage.CertAuthRetriever, enforce bool, logger log.Logger) http.HandlerFunc {
+func CertWithEnrollmentIDMiddleware(next http.Handler, hasher HashFn, store storage.CertAuthRetriever, enforce bool, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cert := GetCert(r.Context())
 		if cert == nil {

--- a/http/mdm/mdm_test.go
+++ b/http/mdm/mdm_test.go
@@ -1,0 +1,76 @@
+package mdm
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/micromdm/nanomdm/log"
+)
+
+const (
+	testHash = "ZZZYYYXXX"
+	testID   = "AAABBBCCC"
+)
+
+func testHashCert(_ *x509.Certificate) string {
+	return testHash
+}
+
+type testCertAuthRetriever struct{}
+
+func (c *testCertAuthRetriever) EnrollmentFromHash(ctx context.Context, hash string) (string, error) {
+	if hash != testHash {
+		return "", errors.New("invalid test hash")
+	}
+	return testID, nil
+}
+
+func TestCertWithEnrollmentIDMiddleware(t *testing.T) {
+	response := []byte("mock response")
+
+	// mock handler
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(response)
+	})
+
+	handler = CertWithEnrollmentIDMiddleware(handler, testHashCert, &testCertAuthRetriever{}, true, log.NopLogger)
+
+	req, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// we requested enforcement, so make sure we get a BadResponse
+	if have, want := rr.Code, http.StatusBadRequest; have != want {
+		t.Errorf("have: %d, want: %d", have, want)
+	}
+
+	req, err = http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req = req.WithContext(context.WithValue(req.Context(), contextKeyCert{}, &x509.Certificate{}))
+
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// now that we have a "cert" included, we should get an OK
+	if have, want := rr.Code, http.StatusOK; have != want {
+		t.Errorf("have: %d, want: %d", have, want)
+	}
+
+	// verify the actual body, too
+	if !bytes.Equal(rr.Body.Bytes(), response) {
+		t.Error("body not equal")
+	}
+}

--- a/http/mdm/mdm_test.go
+++ b/http/mdm/mdm_test.go
@@ -49,7 +49,7 @@ func TestCertWithEnrollmentIDMiddleware(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// we requested enforcement, so make sure we get a BadResponse
+	// we requested enforcement, and did not include a cert, so make sure we get a BadResponse
 	if have, want := rr.Code, http.StatusBadRequest; have != want {
 		t.Errorf("have: %d, want: %d", have, want)
 	}
@@ -59,6 +59,7 @@ func TestCertWithEnrollmentIDMiddleware(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// mock "cert"
 	req = req.WithContext(context.WithValue(req.Context(), contextKeyCert{}, &x509.Certificate{}))
 
 	rr = httptest.NewRecorder()

--- a/service/certauth/certauth.go
+++ b/service/certauth/certauth.go
@@ -97,7 +97,8 @@ func New(next service.CheckinAndCommandService, storage storage.CertAuthStore, o
 	return certAuth
 }
 
-func hashCert(cert *x509.Certificate) string {
+// HashCert returns the string representation
+func HashCert(cert *x509.Certificate) string {
 	hashed := sha256.Sum256(cert.Raw)
 	b := make([]byte, len(hashed))
 	copy(b, hashed[:])
@@ -112,7 +113,7 @@ func (s *CertAuth) associateNewEnrollment(r *mdm.Request) error {
 		return err
 	}
 	logger := ctxlog.Logger(r.Context, s.logger)
-	hash := hashCert(r.Certificate)
+	hash := HashCert(r.Certificate)
 	if hasHash, err := s.storage.HasCertHash(r, hash); err != nil {
 		return err
 	} else if hasHash {
@@ -157,7 +158,7 @@ func (s *CertAuth) validateAssociateExistingEnrollment(r *mdm.Request) error {
 		return err
 	}
 	logger := ctxlog.Logger(r.Context, s.logger)
-	hash := hashCert(r.Certificate)
+	hash := HashCert(r.Certificate)
 	if isAssoc, err := s.storage.IsCertHashAssociated(r, hash); err != nil {
 		return err
 	} else if isAssoc {

--- a/storage/all.go
+++ b/storage/all.go
@@ -7,6 +7,7 @@ type AllStorage interface {
 	PushCertStore
 	CommandEnqueuer
 	CertAuthStore
+	CertAuthRetriever
 	StoreMigrator
 	TokenUpdateTallyStore
 }

--- a/storage/allmulti/certauth.go
+++ b/storage/allmulti/certauth.go
@@ -1,6 +1,8 @@
 package allmulti
 
 import (
+	"context"
+
 	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/storage"
 )
@@ -31,4 +33,11 @@ func (ms *MultiAllStorage) AssociateCertHash(r *mdm.Request, hash string) error 
 		return nil, s.AssociateCertHash(r, hash)
 	})
 	return err
+}
+
+func (ms *MultiAllStorage) EnrollmentFromHash(ctx context.Context, hash string) (*mdm.Request, error) {
+	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
+		return s.EnrollmentFromHash(ctx, hash)
+	})
+	return val.(*mdm.Request), err
 }

--- a/storage/allmulti/certauth.go
+++ b/storage/allmulti/certauth.go
@@ -35,9 +35,9 @@ func (ms *MultiAllStorage) AssociateCertHash(r *mdm.Request, hash string) error 
 	return err
 }
 
-func (ms *MultiAllStorage) EnrollmentFromHash(ctx context.Context, hash string) (*mdm.Request, error) {
+func (ms *MultiAllStorage) EnrollmentFromHash(ctx context.Context, hash string) (string, error) {
 	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
 		return s.EnrollmentFromHash(ctx, hash)
 	})
-	return val.(*mdm.Request), err
+	return val.(string), err
 }

--- a/storage/file/certauth.go
+++ b/storage/file/certauth.go
@@ -70,10 +70,10 @@ func (s *FileStorage) AssociateCertHash(r *mdm.Request, hash string) error {
 	return e.writeFile(CertAuthFilename, []byte(hash))
 }
 
-func (s *FileStorage) EnrollmentFromHash(_ context.Context, hash string) (*mdm.Request, error) {
+func (s *FileStorage) EnrollmentFromHash(_ context.Context, hash string) (string, error) {
 	f, err := os.Open(path.Join(s.path, CertAuthAssociationsFilename))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
@@ -82,10 +82,10 @@ func (s *FileStorage) EnrollmentFromHash(_ context.Context, hash string) (*mdm.R
 		if strings.Contains(text, hash) {
 			split := strings.Split(text, ",")
 			if len(split) < 2 {
-				return nil, errors.New("hash and enrollment id not present on line")
+				return "", errors.New("hash and enrollment id not present on line")
 			}
-			return &mdm.Request{EnrollID: &mdm.EnrollID{ID: split[0]}}, nil
+			return split[0], nil
 		}
 	}
-	return nil, nil
+	return "", nil
 }

--- a/storage/mysql/certauth.go
+++ b/storage/mysql/certauth.go
@@ -52,7 +52,7 @@ UPDATE sha256 = new.sha256;`,
 	return err
 }
 
-func (s *MySQLStorage) EnrollmentFromHash(ctx context.Context, hash string) (*mdm.Request, error) {
+func (s *MySQLStorage) EnrollmentFromHash(ctx context.Context, hash string) (string, error) {
 	var id string
 	err := s.db.QueryRowContext(
 		ctx,
@@ -60,7 +60,7 @@ func (s *MySQLStorage) EnrollmentFromHash(ctx context.Context, hash string) (*md
 		hash,
 	).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return "", nil
 	}
-	return &mdm.Request{EnrollID: &mdm.EnrollID{ID: id}}, err
+	return id, err
 }

--- a/storage/mysql/certauth.go
+++ b/storage/mysql/certauth.go
@@ -2,6 +2,8 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"strings"
 
 	"github.com/micromdm/nanomdm/mdm"
@@ -48,4 +50,17 @@ UPDATE sha256 = new.sha256;`,
 		strings.ToLower(hash),
 	)
 	return err
+}
+
+func (s *MySQLStorage) EnrollmentFromHash(ctx context.Context, hash string) (*mdm.Request, error) {
+	var id string
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT id FROM cert_auth_associations WHERE sha256 = ? LIMIT 1;`,
+		hash,
+	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return &mdm.Request{EnrollID: &mdm.EnrollID{ID: id}}, err
 }

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -19,9 +19,6 @@ func enqueue(ctx context.Context, tx *sql.Tx, ids []string, cmd *mdm.Command) er
 		`INSERT INTO commands (command_uuid, request_type, command) VALUES (?, ?, ?);`,
 		cmd.CommandUUID, cmd.Command.RequestType, cmd.Raw,
 	)
-	if err != nil {
-		return err
-	}
 	query := `INSERT INTO enrollment_queue (id, command_uuid) VALUES (?, ?)`
 	query += strings.Repeat(", (?, ?)", len(ids)-1)
 	args := make([]interface{}, len(ids)*2)

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -56,6 +56,9 @@ SELECT command_uuid FROM commands WHERE command_uuid = ? FOR UPDATE;
 `,
 		uuid,
 	)
+	if err != nil {
+		return err
+	}
 	// delete command result (i.e. NotNows) and this queued command
 	_, err = tx.ExecContext(
 		ctx, `

--- a/storage/pgsql/certauth.go
+++ b/storage/pgsql/certauth.go
@@ -53,7 +53,7 @@ ON CONFLICT ON CONSTRAINT cert_auth_associations_pkey DO UPDATE SET updated_at=n
 	return err
 }
 
-func (s *PgSQLStorage) EnrollmentFromHash(ctx context.Context, hash string) (*mdm.Request, error) {
+func (s *PgSQLStorage) EnrollmentFromHash(ctx context.Context, hash string) (string, error) {
 	var id string
 	err := s.db.QueryRowContext(
 		ctx,
@@ -61,7 +61,7 @@ func (s *PgSQLStorage) EnrollmentFromHash(ctx context.Context, hash string) (*md
 		hash,
 	).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
+		return "", nil
 	}
-	return &mdm.Request{EnrollID: &mdm.EnrollID{ID: id}}, err
+	return id, err
 }

--- a/storage/pgsql/certauth.go
+++ b/storage/pgsql/certauth.go
@@ -2,6 +2,8 @@ package pgsql
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"strings"
 
 	"github.com/micromdm/nanomdm/mdm"
@@ -49,4 +51,17 @@ ON CONFLICT ON CONSTRAINT cert_auth_associations_pkey DO UPDATE SET updated_at=n
 		strings.ToLower(hash),
 	)
 	return err
+}
+
+func (s *PgSQLStorage) EnrollmentFromHash(ctx context.Context, hash string) (*mdm.Request, error) {
+	var id string
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT id FROM cert_auth_associations WHERE sha256 = $1 LIMIT 1;`,
+		hash,
+	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return &mdm.Request{EnrollID: &mdm.EnrollID{ID: id}}, err
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -66,10 +66,9 @@ type CertAuthStore interface {
 }
 
 type CertAuthRetriever interface {
-	// EnrollmentFromHash retrieves an MDM request from a cert hash.
-	// Implementations should return a nil pointer if no result is found.
-	// The ID member ought to be populated when non-nil.
-	EnrollmentFromHash(ctx context.Context, hash string) (*mdm.Request, error)
+	// EnrollmentFromHash retrieves an enrollment ID from a cert hash.
+	// Implementations should return an empty string if no result is found.
+	EnrollmentFromHash(ctx context.Context, hash string) (string, error)
 }
 
 // StoreMigrator retrieves MDM check-ins

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -65,6 +65,13 @@ type CertAuthStore interface {
 	AssociateCertHash(r *mdm.Request, hash string) error
 }
 
+type CertAuthRetriever interface {
+	// EnrollmentFromHash retrieves an MDM request from a cert hash.
+	// Implementations should return a nil pointer if no result is found.
+	// The ID member ought to be populated when non-nil.
+	EnrollmentFromHash(ctx context.Context, hash string) (*mdm.Request, error)
+}
+
 // StoreMigrator retrieves MDM check-ins
 type StoreMigrator interface {
 	// RetrieveMigrationCheckins sends the (decoded) forms of


### PR DESCRIPTION
Declarative Device Management has introduced the concept of an "MDM" Authentication style for asset URLs. For example:

https://github.com/apple/device-management/blob/b838baacf2e790db729b6ca3f52724adc8bfb96d/declarative/declarations/assets/credential.acme.yaml#L43-L57

So for content we want to protect this means we need to authenticate the MDM client identity certificate coming into the MDM server. However because file (or other content) serving is out of scope for NanoMDM we implement this as reverse proxy. When you specify the `-authproxy` switch on the command line with a URL (or use the relevant HTTP handlers in code) NanoMDM transparently authenticates the incoming HTTP request using MDM style authentication (in the same way we verify `CheckInURL` and `ServerURL` connections) then proxy the request to the URL provided in the command line switch.

The proxy URL in the default server is at `/authproxy/`. So if you request `/authproxy/foo/bar` and you specified `-authproxy 'http://[::1]:9008'` the server will append `/foo/bar` to the end of the authproxy URL to come up with: `http://[::1]:9008/foo/bar`.

The pre-proxy verification involves a few checks:

  * The request has a certificate (either the `Mdm-Signature` header or the passed-in certificate with `-cert-header`)
  * The request's certificate was issued from a CA that NanoMDM trusts (`-ca` switch)
  * The request's certificate matches any previously enrolled MDM device enrollment (by the cert's SHA-256 hash).

If these conditions are met we allow the request to reach the reverse proxy and be passed on. We set the `X-Enrollment-Id` header on the outgoing request to let the target HTTP server know what enrollment ID of the device is trying to connect to it.

Internally this is implementation as another method on the storage backends to lookup an enrollment ID based on certificate hash, an authenticating middleware HTTP handler, and, of course, the reverse proxy itself.

Still TODO:

- [x] Docs (Operations Guide)
- [x] Test(s)