### PR TITLE
GetToken check-in message framing

### DIFF
--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -110,10 +110,13 @@ func main() {
 		stdlog.Fatal(err)
 	}
 
+	tokenMux := nanomdm.NewTokenMux()
+
 	// create 'core' MDM service
 	nanoOpts := []nanomdm.Option{
-		nanomdm.WithLogger(logger.With("service", "nanomdm")),
 		nanomdm.WithUserAuthenticate(nanomdm.NewUAService(mdmStorage, *flUAZLChal)),
+		nanomdm.WithGetToken(tokenMux),
+		nanomdm.WithLogger(logger.With("service", "nanomdm")),
 	}
 	if *flDMURLPfx != "" {
 		logger.Debug("msg", "declarative management setup", "url", *flDMURLPfx)

--- a/docs/enroll.mobileconfig
+++ b/docs/enroll.mobileconfig
@@ -46,6 +46,7 @@
 			<array>
 				<string>com.apple.mdm.per-user-connections</string>
 				<string>com.apple.mdm.bootstraptoken</string>
+				<string>com.apple.mdm.token</string>
 			</array>
 			<key>ServerURL</key>
 			<string>https://mdm.example.org/mdm</string>

--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -135,14 +135,8 @@ func (m *GetToken) Validate() error {
 	if m.TokenServiceType == "" {
 		return errors.New("empty GetToken TokenServiceType")
 	}
-	switch m.TokenServiceType {
-	case "com.apple.maid":
-	case "com.apple.watch.pairing":
-		if m.TokenParameters == nil {
-			return fmt.Errorf("empty GetToken TokenParameters for %s TokenServiceType", m.TokenServiceType)
-		}
-	default:
-		return fmt.Errorf("invalid GetToken TokenServiceType: %s", m.TokenServiceType)
+	if m.TokenServiceType == "com.apple.watch.pairing" && m.TokenParameters == nil {
+		return fmt.Errorf("nil TokenParameters for GetToken: %s", m.TokenServiceType)
 	}
 	return nil
 }

--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -103,6 +103,50 @@ type DeclarativeManagement struct {
 	Raw      []byte `plist:"-"` // Original XML plist
 }
 
+// TokenParameters is a representation of a "GetTokenRequest.TokenParameters" structure.
+// See https://developer.apple.com/documentation/devicemanagement/gettokenrequest/tokenparameters
+type TokenParameters struct {
+	PhoneUDID     string
+	SecurityToken string
+	WatchUDID     string
+}
+
+// GetTokenResponse is a representation of a "GetTokenResponse" structure.
+// See https://developer.apple.com/documentation/devicemanagement/gettokenresponse
+type GetTokenResponse struct {
+	TokenData []byte
+}
+
+// GetToken is a representation of a "GetToken" check-in message type.
+// See https://developer.apple.com/documentation/devicemanagement/get_token
+type GetToken struct {
+	Enrollment
+	MessageType
+	TokenServiceType string
+	TokenParameters  *TokenParameters `plist:",omitempty"`
+	Raw              []byte           `plist:"-"` // Original XML plist
+}
+
+// Validate validates a GetToken check-in message.
+func (m *GetToken) Validate() error {
+	if m == nil {
+		return errors.New("nil GetToken")
+	}
+	if m.TokenServiceType == "" {
+		return errors.New("empty GetToken TokenServiceType")
+	}
+	switch m.TokenServiceType {
+	case "com.apple.maid":
+	case "com.apple.watch.pairing":
+		if m.TokenParameters == nil {
+			return fmt.Errorf("empty GetToken TokenParameters for %s TokenServiceType", m.TokenServiceType)
+		}
+	default:
+		return fmt.Errorf("invalid GetToken TokenServiceType: %s", m.TokenServiceType)
+	}
+	return nil
+}
+
 // newCheckinMessageForType returns a pointer to a check-in struct for MessageType t
 func newCheckinMessageForType(t string, raw []byte) interface{} {
 	switch t {
@@ -120,6 +164,8 @@ func newCheckinMessageForType(t string, raw []byte) interface{} {
 		return &UserAuthenticate{Raw: raw}
 	case "DeclarativeManagement":
 		return &DeclarativeManagement{Raw: raw}
+	case "GetToken":
+		return &GetToken{Raw: raw}
 	default:
 		return nil
 	}

--- a/mdm/checkin_test.go
+++ b/mdm/checkin_test.go
@@ -109,3 +109,36 @@ func TestTokenUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTokenMAID(t *testing.T) {
+	test := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MessageType</key>
+	<string>GetToken</string>
+	<key>UDID</key>
+	<string>test</string>
+	<key>TokenServiceType</key>
+	<string>com.apple.maid</string>
+</dict>
+</plist>
+`
+	m, err := DecodeCheckin([]byte(test))
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, ok := m.(*GetToken)
+	if !ok {
+		t.Fatal("incorrect decoded check-in message type")
+	}
+	if err := msg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if msg, want, have := "invalid UDID", "test", msg.UDID; have != want {
+		t.Errorf("%s: %q, want: %q", msg, have, want)
+	}
+	if msg, want, have := "invalid TokenServiceType", "com.apple.maid", msg.TokenServiceType; have != want {
+		t.Errorf("%s: %q, want: %q", msg, have, want)
+	}
+}

--- a/service/certauth/helpers_test.go
+++ b/service/certauth/helpers_test.go
@@ -81,6 +81,10 @@ func (s *NopService) DeclarativeManagement(r *mdm.Request, m *mdm.DeclarativeMan
 	return nil, nil
 }
 
+func (s *NopService) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetTokenResponse, error) {
+	return nil, nil
+}
+
 func (s *NopService) CommandAndReportResults(r *mdm.Request, results *mdm.CommandResults) (*mdm.Command, error) {
 	return nil, nil
 }

--- a/service/certauth/service.go
+++ b/service/certauth/service.go
@@ -53,6 +53,13 @@ func (s *CertAuth) DeclarativeManagement(r *mdm.Request, m *mdm.DeclarativeManag
 	return s.next.DeclarativeManagement(r, m)
 }
 
+func (s *CertAuth) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetTokenResponse, error) {
+	if err := s.validateOrAssociateForExistingEnrollment(r, &m.Enrollment); err != nil {
+		return nil, err
+	}
+	return s.next.GetToken(r, m)
+}
+
 func (s *CertAuth) CommandAndReportResults(r *mdm.Request, results *mdm.CommandResults) (*mdm.Command, error) {
 	if err := s.validateOrAssociateForExistingEnrollment(r, &results.Enrollment); err != nil {
 		return nil, err

--- a/service/dump/dump.go
+++ b/service/dump/dump.go
@@ -2,6 +2,7 @@
 package dump
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 
@@ -68,6 +69,16 @@ func (svc *Dumper) GetBootstrapToken(r *mdm.Request, m *mdm.GetBootstrapToken) (
 		svc.file.Write([]byte(fmt.Sprintf("Bootstrap token: %s\n", bsToken.BootstrapToken.String())))
 	}
 	return bsToken, err
+}
+
+func (svc *Dumper) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetTokenResponse, error) {
+	svc.file.Write(m.Raw)
+	token, err := svc.next.GetToken(r, m)
+	if token != nil && len(token.TokenData) > 0 {
+		b64 := base64.StdEncoding.EncodeToString(token.TokenData)
+		svc.file.WriteString("GetToken TokenData: " + b64 + "\n")
+	}
+	return token, err
 }
 
 func (svc *Dumper) CommandAndReportResults(r *mdm.Request, results *mdm.CommandResults) (*mdm.Command, error) {

--- a/service/microwebhook/service.go
+++ b/service/microwebhook/service.go
@@ -143,3 +143,17 @@ func (w *MicroWebhook) DeclarativeManagement(r *mdm.Request, m *mdm.DeclarativeM
 	}
 	return nil, postWebhookEvent(r.Context, w.client, w.url, ev)
 }
+
+func (w *MicroWebhook) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetTokenResponse, error) {
+	ev := &Event{
+		Topic:     "mdm.GetToken",
+		CreatedAt: time.Now(),
+		CheckinEvent: &CheckinEvent{
+			UDID:         m.UDID,
+			EnrollmentID: m.EnrollmentID,
+			RawPayload:   m.Raw,
+			Params:       r.Params,
+		},
+	}
+	return nil, postWebhookEvent(r.Context, w.client, w.url, ev)
+}

--- a/service/multi/multi.go
+++ b/service/multi/multi.go
@@ -121,6 +121,16 @@ func (ms *MultiService) DeclarativeManagement(r *mdm.Request, m *mdm.Declarative
 	return retBytes, err
 }
 
+func (ms *MultiService) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetTokenResponse, error) {
+	resp, err := ms.svcs[0].GetToken(r, m)
+	rc := ms.RequestWithContext(r)
+	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+		_, err := svc.GetToken(rc, m)
+		return err
+	})
+	return resp, err
+}
+
 func (ms *MultiService) CommandAndReportResults(r *mdm.Request, results *mdm.CommandResults) (*mdm.Command, error) {
 	cmd, err := ms.svcs[0].CommandAndReportResults(r, results)
 	rc := ms.RequestWithContext(r)

--- a/service/nanomdm/service.go
+++ b/service/nanomdm/service.go
@@ -23,6 +23,9 @@ type Service struct {
 
 	// UserAuthenticate processor
 	ua service.UserAuthenticate
+
+	// GetToken handler
+	gt service.GetToken
 }
 
 // normalize generates enrollment IDs that are used by other
@@ -70,6 +73,13 @@ func WithDeclarativeManagement(dm service.DeclarativeManagement) Option {
 func WithUserAuthenticate(ua service.UserAuthenticate) Option {
 	return func(s *Service) {
 		s.ua = ua
+	}
+}
+
+// WithGetToken configures a GetToken check-in message handler.
+func WithGetToken(gt service.GetToken) Option {
+	return func(s *Service) {
+		s.gt = gt
 	}
 }
 
@@ -186,6 +196,21 @@ func (s *Service) DeclarativeManagement(r *mdm.Request, message *mdm.Declarative
 		return nil, errors.New("no Declarative Management handler")
 	}
 	return s.dm.DeclarativeManagement(r, message)
+}
+
+// GetToken implements the GetToken Check-in message interface.
+func (s *Service) GetToken(r *mdm.Request, message *mdm.GetToken) (*mdm.GetTokenResponse, error) {
+	if err := s.setupRequest(r, &message.Enrollment); err != nil {
+		return nil, err
+	}
+	ctxlog.Logger(r.Context, s.logger).Info(
+		"msg", "GetToken",
+		"token_service_type", message.TokenServiceType,
+	)
+	if s.gt == nil {
+		return nil, errors.New("no GetToken handler")
+	}
+	return s.gt.GetToken(r, message)
 }
 
 // CommandAndReportResults command report and next-command request implementation.

--- a/service/nanomdm/token.go
+++ b/service/nanomdm/token.go
@@ -1,0 +1,69 @@
+package nanomdm
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/service"
+)
+
+type StaticToken struct {
+	token []byte
+}
+
+func NewStaticToken(token []byte) *StaticToken {
+	return &StaticToken{token: token}
+}
+
+func (t *StaticToken) GetToken(_ *mdm.Request, _ *mdm.GetToken) (*mdm.GetTokenResponse, error) {
+	return &mdm.GetTokenResponse{TokenData: t.token}, nil
+}
+
+// TokenServiceTypeMux is a middleware multiplexer for GetToken check-in messages.
+// A TokenServiceType string is associated with a GetToken handler and
+// then dispatched appropriately with a matching TokenServiceType.
+type TokenServiceTypeMux struct {
+	typesMu sync.RWMutex
+	types   map[string]service.GetToken
+}
+
+// NewTokenServiceTypeMux creates a new TokenServiceTypeMux.
+func NewTokenServiceTypeMux() *TokenServiceTypeMux { return &TokenServiceTypeMux{} }
+
+// Handle registers a GetToken handler for the given service type.
+// See https://developer.apple.com/documentation/devicemanagement/gettokenrequest
+func (mux *TokenServiceTypeMux) Handle(serviceType string, handler service.GetToken) {
+	if serviceType == "" {
+		panic("tokenmux: invalid service type")
+	}
+	if handler == nil {
+		panic("tokenmux: invalid handler")
+	}
+	mux.typesMu.Lock()
+	defer mux.typesMu.Unlock()
+	if mux.types == nil {
+		mux.types = make(map[string]service.GetToken)
+	} else if _, exists := mux.types[serviceType]; exists {
+		panic("tokenmux: multiple registrations for " + serviceType)
+	}
+	mux.types[serviceType] = handler
+}
+
+// GetToken is the middleware that dispatches a GetToken handler based on service type.
+func (mux *TokenServiceTypeMux) GetToken(r *mdm.Request, t *mdm.GetToken) (*mdm.GetTokenResponse, error) {
+	var next service.GetToken
+	var serviceType string
+	if t != nil {
+		serviceType = t.TokenServiceType
+	}
+	mux.typesMu.RLock()
+	if mux.types != nil {
+		next = mux.types[serviceType]
+	}
+	mux.typesMu.RUnlock()
+	if next == nil {
+		return nil, fmt.Errorf("no handler for TokenServiceType: %v", serviceType)
+	}
+	return next.GetToken(r, t)
+}

--- a/service/nanomdm/token_test.go
+++ b/service/nanomdm/token_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestToken(t *testing.T) {
-	m := NewTokenServiceTypeMux()
+	m := NewTokenMux()
 	inTok := []byte("hello")
 	m.Handle("com.apple.maid", NewStaticToken(inTok))
 	inMDMGetToken := &mdm.GetToken{TokenServiceType: "com.apple.maid"}

--- a/service/nanomdm/token_test.go
+++ b/service/nanomdm/token_test.go
@@ -2,26 +2,48 @@ package nanomdm
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/micromdm/nanomdm/mdm"
 )
 
+func newTokenMDMReq() *mdm.Request {
+	return &mdm.Request{Context: context.Background()}
+}
+
+func newGetToken(serviceType string, id string) *mdm.GetToken {
+	return &mdm.GetToken{
+		TokenServiceType: serviceType,
+		Enrollment:       mdm.Enrollment{UDID: id},
+	}
+}
+
 func TestToken(t *testing.T) {
+	tokenTestData := []byte("hello")
+
+	// create muxer
 	m := NewTokenMux()
-	inTok := []byte("hello")
-	m.Handle("com.apple.maid", NewStaticToken(inTok))
-	inMDMGetToken := &mdm.GetToken{TokenServiceType: "com.apple.maid"}
-	outTok, err := m.GetToken(nil, inMDMGetToken)
+
+	// associate a new static token handler with a type
+	m.Handle("com.apple.maid", NewStaticToken(tokenTestData))
+
+	// create a new NanoMDM service
+	s := New(nil, WithGetToken(m))
+
+	// dispatch a GetToken check-in message
+	resp, err := s.GetToken(newTokenMDMReq(), newGetToken("com.apple.maid", "AAAA-1111"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(inTok, outTok.TokenData) {
+
+	// check that our token data our matches (from the static handler)
+	if !bytes.Equal(tokenTestData, resp.TokenData) {
 		t.Error("input and output not equal")
 	}
-	// invalid type
-	inMDMGetToken = &mdm.GetToken{TokenServiceType: "com.apple.does-not-exist"}
-	_, err = m.GetToken(nil, inMDMGetToken)
+
+	// supply an invalid service type (not handled) and expect an error
+	_, err = s.GetToken(newTokenMDMReq(), newGetToken("com.apple.does-not-exist", "AAAA-1111"))
 	if err == nil {
 		t.Fatal("should be an error")
 	}

--- a/service/nanomdm/token_test.go
+++ b/service/nanomdm/token_test.go
@@ -5,11 +5,58 @@ import (
 	"context"
 	"testing"
 
+	"github.com/groob/plist"
 	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/service"
 )
 
 func newTokenMDMReq() *mdm.Request {
 	return &mdm.Request{Context: context.Background()}
+}
+
+const tokenTestCheckin = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MessageType</key>
+	<string>GetToken</string>
+	<key>UDID</key>
+	<string>test</string>
+	<key>TokenServiceType</key>
+	<string>com.apple.maid</string>
+</dict>
+</plist>
+`
+
+func TestTokenFull(t *testing.T) {
+	tokenTestData := []byte("hello")
+
+	// create muxer
+	m := NewTokenMux()
+
+	// associate a new static token handler with a type
+	m.Handle("com.apple.maid", NewStaticToken(tokenTestData))
+
+	// create a new NanoMDM service with our token muxer
+	s := New(nil, WithGetToken(m))
+
+	// process GetToken check-in message
+	respBytes, err := service.CheckinRequest(s, newTokenMDMReq(), []byte(tokenTestCheckin))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// unmarshal response bytes
+	resp := new(mdm.GetTokenResponse)
+	err = plist.Unmarshal(respBytes, resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that our token data matches
+	if want, have := string(tokenTestData), string(resp.TokenData); have != want {
+		t.Errorf("have %q; want %q", have, want)
+	}
 }
 
 func newGetToken(serviceType string, id string) *mdm.GetToken {
@@ -28,7 +75,7 @@ func TestToken(t *testing.T) {
 	// associate a new static token handler with a type
 	m.Handle("com.apple.maid", NewStaticToken(tokenTestData))
 
-	// create a new NanoMDM service
+	// create a new NanoMDM service with our token muxer
 	s := New(nil, WithGetToken(m))
 
 	// dispatch a GetToken check-in message

--- a/service/nanomdm/token_test.go
+++ b/service/nanomdm/token_test.go
@@ -1,0 +1,28 @@
+package nanomdm
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/micromdm/nanomdm/mdm"
+)
+
+func TestToken(t *testing.T) {
+	m := NewTokenServiceTypeMux()
+	inTok := []byte("hello")
+	m.Handle("com.apple.maid", NewStaticToken(inTok))
+	inMDMGetToken := &mdm.GetToken{TokenServiceType: "com.apple.maid"}
+	outTok, err := m.GetToken(nil, inMDMGetToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(inTok, outTok.TokenData) {
+		t.Error("input and output not equal")
+	}
+	// invalid type
+	inMDMGetToken = &mdm.GetToken{TokenServiceType: "com.apple.does-not-exist"}
+	_, err = m.GetToken(nil, inMDMGetToken)
+	if err == nil {
+		t.Fatal("should be an error")
+	}
+}

--- a/service/request.go
+++ b/service/request.go
@@ -78,6 +78,22 @@ func CheckinRequest(svc Checkin, r *mdm.Request, bodyBytes []byte) ([]byte, erro
 		if err != nil {
 			err = fmt.Errorf("declarativemanagement service: %w", err)
 		}
+	case *mdm.GetToken:
+		if err := m.Validate(); err != nil {
+			return nil, fmt.Errorf("gettoken validate: %w", err)
+		}
+		resp, err := svc.GetToken(r, m)
+		if err != nil {
+			return nil, fmt.Errorf("gettoken service: %w", err)
+		}
+		if resp == nil {
+			return nil, errors.New("gettoken service: no response")
+		}
+		respBytes, err = plist.Marshal(resp)
+		if err != nil {
+			return nil, fmt.Errorf("gettoken marshal: %w", err)
+		}
+		return respBytes, nil
 	default:
 		return nil, errors.New("unhandled check-in request type")
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -16,6 +16,12 @@ type UserAuthenticate interface {
 	UserAuthenticate(*mdm.Request, *mdm.UserAuthenticate) ([]byte, error)
 }
 
+// GetToken is the interface for handling a GetToken check-in message.
+// See https://developer.apple.com/documentation/devicemanagement/get_token
+type GetToken interface {
+	GetToken(*mdm.Request, *mdm.GetToken) (*mdm.GetTokenResponse, error)
+}
+
 // Checkin represents the various check-in requests.
 // See https://developer.apple.com/documentation/devicemanagement/check-in
 type Checkin interface {
@@ -26,6 +32,7 @@ type Checkin interface {
 	GetBootstrapToken(*mdm.Request, *mdm.GetBootstrapToken) (*mdm.BootstrapToken, error)
 	UserAuthenticate
 	DeclarativeManagement
+	GetToken
 }
 
 // CommandAndReportResults represents the command report and next-command request.


### PR DESCRIPTION
Initial implementation of the *framing* for the `GetToken` check-in message.

**Note:** this is just the scaffolding to (eventually) support handling/handing-off of the GetToken check-in [`TokenServiceType`s](https://developer.apple.com/documentation/devicemanagement/gettokenrequest) of `com.apple.maid` and `com.apple.watch.pairing`.