### PR TITLE
configure identity verification from CLI

### DIFF
--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -116,6 +116,11 @@ func main() {
 		if err != nil {
 			stdlog.Fatal(err)
 		}
+		logger.Info(
+			"msg", "reduced security: signature-only verifier",
+			// double up and use a err in case that key is used for reporting
+			"err", "reduced security: signature-only verifier",
+		)
 	default:
 		stdlog.Fatal(fmt.Errorf("invalid verify flag: %s", *flVerify))
 	}

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -177,6 +177,15 @@ By default NanoMDM will respond to a `UserAuthenticate` message with an HTTP 410
 
 Note that the `UserAuthenticate` message is only for "directory" MDM users and not the "primary" MDM user enrollment. See also [Apple's discussion of UserAthenticate](https://developer.apple.com/documentation/devicemanagement/userauthenticate#discussion) for more information.
 
+### -verify string
+
+* device identity verification type (default "pool")
+
+Selects which verifier to use to verify the device identity certificate:
+
+* `pool`: uses the "pool" verifier which can configure multiple CAs and intermediate certificates.
+* `signature-only`: uses the "signature" verifier which only verifies a device identity certificate was signed by a single CA. Notably it does not check identity certificate validity (expiry). **WARNING**: this *reduces security* of the signature checking.
+
 ## HTTP endpoints & APIs
 
 ### MDM

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -186,6 +186,8 @@ Selects which verifier to use to verify the device identity certificate:
 * `pool`: uses the "pool" verifier which can configure multiple CAs and intermediate certificates.
 * `signature-only`: uses the "signature" verifier which only verifies a device identity certificate was signed by a single CA. Notably it does not check identity certificate validity (expiry). **WARNING**: this *reduces security* of the signature checking.
 
+*Example:* `-verify pool`
+
 ## HTTP endpoints & APIs
 
 ### MDM


### PR DESCRIPTION
Add the ability to configure the device identity verification type from the CLI. The actual verifiers themselves have existed for a while (for use as library code), this just exposes a CLI flag.

I'm reasonably concerned about this as it exposes a trivial switch to lower the security of the system. Those types of things tend to just get forgotten about.