### PR TITLE
warn if a DDM url does not contain a trailing slash

### DIFF
--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/micromdm/nanomdm/certverify"
@@ -116,7 +117,11 @@ func main() {
 		nanomdm.WithUserAuthenticate(nanomdm.NewUAService(mdmStorage, *flUAZLChal)),
 	}
 	if *flDMURLPfx != "" {
-		logger.Debug("msg", "declarative management setup", "url", *flDMURLPfx)
+		var warningText string
+		if !strings.HasSuffix(*flDMURLPfx, "/") {
+			warningText = ": warning: URL has no trailing slash"
+		}
+		logger.Debug("msg", "declarative management setup"+warningText, "url", *flDMURLPfx)
 		dm, err := nanomdm.NewDeclarativeManagementHTTPCaller(*flDMURLPfx, http.DefaultClient)
 		if err != nil {
 			stdlog.Fatal(err)

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -135,6 +135,8 @@ This switch disables MDM client capability. This effecitvely turns this running 
 
 Specifies the "base" URL to send Declarative Management requests to. The full URL is constructed from this base URL appended with the type of Declarative Management ["Endpoint" request](https://developer.apple.com/documentation/devicemanagement/declarativemanagementrequest?language=objc) such as "status" or "declaration-items". Each HTTP request includes the NanoMDM enrollment ID as the HTTP header "X-Enrollment-ID". See [this blog post](https://micromdm.io/blog/wwdc21-declarative-management/) for more details.
 
+Note that the URL should likely have a trailing slash. Otherwise path elements of the URL may to be cut off but by Golang's relative URL path resolver.
+
 ### -migration
 
 * HTTP endpoint for enrollment migrations


### PR DESCRIPTION
Also add documentation to this effect for the `-dm` switch.