### PR TITLE
API and HTTP refactor

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,138 @@
+// Package api defines a consistent Go API for enqueueing or sending APNs pushes
+// to multiple enrollment IDs.
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/micromdm/nanolib/log"
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/push"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+// PushEnqueuer can enqueue commands and send APNs pushes.
+type PushEnqueuer struct {
+	logger log.Logger
+	store  storage.CommandEnqueuer
+	pusher push.Pusher
+	noPush bool
+}
+
+// PushEnqueuerOptions configures the push enqueuer.
+type PushEnqueuerOption func(*PushEnqueuer) error
+
+// WithLogger configures a logger on a push enqueuer.
+func WithLogger(logger log.Logger) PushEnqueuerOption {
+	return func(pe *PushEnqueuer) error {
+		pe.logger = logger
+		return nil
+	}
+}
+
+// WithNoPush disables push attempts.
+func WithNoPush() PushEnqueuerOption {
+	return func(pe *PushEnqueuer) error {
+		pe.noPush = true
+		return nil
+	}
+}
+
+// NewPushEnqueuer creates a new push enqueuer.
+func NewPushEnqueuer(store storage.CommandEnqueuer, pusher push.Pusher, opts ...PushEnqueuerOption) (*PushEnqueuer, error) {
+	if store == nil && pusher == nil {
+		return nil, errors.New("store and pusher both nil")
+	}
+	pe := &PushEnqueuer{
+		logger: nil,
+		store:  store,
+		pusher: pusher,
+	}
+	for _, opt := range opts {
+		if err := opt(pe); err != nil {
+			return nil, err
+		}
+	}
+	return pe, nil
+}
+
+// Push sends APNs notifications to ids.
+func (pe *PushEnqueuer) Push(ctx context.Context, ids []string) (*APIResult, int, error) {
+	return pe.EnqueueWithPush(ctx, nil, ids, false)
+}
+
+// EnqueueWithPush enqueues command and can send APNs pushes to ids.
+// A command cannot be nil while noPush is true.
+// The return integer is an indicator of errors with the actual errors
+// contained within the API result.
+// A 500 value indicates only errors (with no successes).
+// A 207 value indicates some sucesses and some failures.
+// A 200 value indicates no errors (with only accesses).
+// Any other value is undefined.
+func (pe *PushEnqueuer) EnqueueWithPush(ctx context.Context, command *mdm.Command, ids []string, noPush bool) (*APIResult, int, error) {
+	// setup our result accumulator
+	r := &APIResult{
+		NoPush: noPush || pe.noPush,
+	}
+
+	if command == nil && noPush {
+		return r, 500, errors.New("must enqueue or push")
+	}
+
+	if command != nil {
+		doEnqueue(ctx, r, pe.logger, pe.store, command, ids)
+	}
+
+	if !noPush && !pe.noPush && r.EnqueueError == nil {
+		// TODO: only push to non-erroring enrollment IDs
+		doPush(ctx, r, pe.logger, pe.pusher, ids)
+	}
+
+	return r, code(r, len(ids)), nil
+}
+
+// code translates an [APIResult] to an interger code.
+// See [EnqueueWithPush] for specific code meanings.
+func code(r *APIResult, idCount int) int {
+	if r == nil {
+		return 500
+	}
+
+	if r.PushError != nil || r.EnqueueError != nil {
+		// if there was any high-level error
+		// we consider that a complete failure.
+		return 500
+	}
+
+	var errCt int
+	for _, er := range r.Status {
+		if er.PushError != nil || er.EnqueueError != nil {
+			errCt++
+		}
+	}
+
+	if errCt < 1 {
+		// if no high-level errors and no individual erros then all good.
+		return 200
+	} else if errCt == idCount {
+		// same amount of errors as we attempted to send things
+		return 500
+	} else if errCt < idCount {
+		return 207
+	}
+
+	// more errCt than idCount? assume that's bad.
+	return 500
+}
+
+// RawCommandEnqueueWithPush enqueues rawCommand and can send APNs pushes to ids.
+// See [EnqueueWithPush] for calling semantics.
+func (pe *PushEnqueuer) RawCommandEnqueueWithPush(ctx context.Context, rawCommand []byte, ids []string, noPush bool) (*APIResult, int, error) {
+	command, err := mdm.DecodeCommand(rawCommand)
+	if err != nil {
+		return nil, 500, fmt.Errorf("decoding command: %w", err)
+	}
+	return pe.EnqueueWithPush(ctx, command, ids, noPush)
+}

--- a/api/do.go
+++ b/api/do.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/push"
+	"github.com/micromdm/nanomdm/storage"
+
+	"github.com/micromdm/nanolib/log"
+	"github.com/micromdm/nanolib/log/ctxlog"
+)
+
+// doPush sends MDM APNs push notifications to ids using pusher.
+// Results and/or errors are accumulated in r and logged to logger.
+func doPush(ctx context.Context, r *APIResult, logger log.Logger, pusher push.Pusher, ids []string) {
+	var errCt int
+	var err error
+	logs := []interface{}{
+		"msg", "push",
+		"id_count", len(ids),
+	}
+	if logger != nil {
+		// setup our deferred logger
+		defer func() {
+			if err != nil || errCt > 0 {
+				if errCt > 0 {
+					logs = append(logs, "errs", errCt)
+				}
+				if err != nil {
+					logs = append(logs, "err", err)
+				}
+				ctxlog.Logger(ctx, logger).Info(logs...)
+			} else {
+				ctxlog.Logger(ctx, logger).Debug(logs...)
+			}
+		}()
+	}
+
+	if r == nil {
+		err = errors.New("nil accumulator")
+		return
+	}
+
+	if len(ids) > 0 {
+		logs = append(logs, "id_first", ids[0])
+	}
+
+	// even though command UUID and RequestType aren't really
+	// applicable to pushing, include the logs here to try and
+	// connect any dogs in the logging.
+	if r.CommandUUID != "" {
+		logs = append(logs, "command_uuid", r.CommandUUID)
+	}
+	if r.RequestType != "" {
+		logs = append(logs, "request_type", r.RequestType)
+	}
+
+	if pusher == nil {
+		err = errors.New("nil pusher")
+		r.PushError = NewError(err)
+		return
+	}
+
+	// send APNs push notification(s)
+	pr, err := pusher.Push(ctx, ids)
+	if err != nil {
+		r.PushError = NewError(err)
+	}
+
+	if len(pr) > 0 && r.Status == nil {
+		// init the results if there are any
+		r.Status = make(map[string]EnrollmentResult)
+	}
+
+	// loop through any push responses and populate results
+	var pushCt int
+	for id, pushResponse := range pr {
+		er := r.Status[id]
+		er.PushID = pushResponse.Id
+		if pushResponse.Err != nil {
+			errCt++
+			er.PushError = NewError(pushResponse.Err)
+		} else {
+			// we assume a lack of error means a "success"
+			// however PushID could conceivably be empty still,
+			// suggesting something else went wrong.
+			pushCt++
+		}
+		r.Status[id] = er
+	}
+
+	logs = append(logs, "count", pushCt)
+}
+
+// doEnqueue enqueues the MDM command to ids using store.
+// Results and/or errors are accumulated in r and logged to logger.
+func doEnqueue(ctx context.Context, r *APIResult, logger log.Logger, store storage.CommandEnqueuer, cmd *mdm.Command, ids []string) {
+	var idErrs map[string]error
+	var err error
+	logs := []interface{}{
+		"msg", "enqueue",
+		"id_count", len(ids),
+	}
+	if logger != nil {
+		// setup our deferred logger
+		defer func() {
+			if err != nil || len(idErrs) > 0 {
+				if len(idErrs) > 0 {
+					logs = append(logs, "errs", len(idErrs))
+				}
+				if err != nil {
+					logs = append(logs, "err", err)
+				}
+				ctxlog.Logger(ctx, logger).Info(logs...)
+			} else {
+				ctxlog.Logger(ctx, logger).Debug(logs...)
+			}
+		}()
+	}
+
+	if len(ids) > 0 {
+		logs = append(logs, "id_first", ids[0])
+	}
+
+	if r == nil {
+		err = errors.New("nil accumulator")
+		return
+	}
+
+	if cmd != nil {
+		r.CommandUUID = cmd.CommandUUID
+		r.RequestType = cmd.Command.RequestType
+		logs = append(logs,
+			"command_uuid", r.CommandUUID,
+			"request_type", r.RequestType,
+		)
+	}
+
+	if store == nil {
+		err = errors.New("nil store")
+		r.EnqueueError = NewError(err)
+		return
+	}
+
+	// enqueue command
+	idErrs, err = store.EnqueueCommand(ctx, ids, cmd)
+	if err != nil {
+		r.EnqueueError = NewError(err)
+	}
+
+	if len(idErrs) > 0 && r.Status == nil {
+		// init the results if there are any
+		r.Status = make(map[string]EnrollmentResult)
+	}
+
+	// loop through any id errors and populate results
+	for id, err := range idErrs {
+		er := r.Status[id]
+		if err == nil {
+			err = errors.New("unknown enqueue error")
+		}
+		er.EnqueueError = NewError(err)
+		r.Status[id] = er
+	}
+
+	logs = append(logs, "count", len(ids)-len(idErrs))
+}

--- a/api/error.go
+++ b/api/error.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// Error wraps errors for marshalling and unmarshalling.
+type Error struct {
+	Err error
+}
+
+// NewError contains err in a marshalling and unmarhalling wrapper.
+func NewError(err error) *Error {
+	return &Error{err}
+}
+
+// Valid returns true if e and our error are not nil.
+func (e *Error) Valid() bool {
+	if e == nil || e.Err == nil {
+		return false
+	}
+	return true
+}
+
+// Error returns the error string.
+func (e *Error) Error() string {
+	if !e.Valid() {
+		return ""
+	}
+	return e.Err.Error()
+}
+
+// Unwrap returns the contained error.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+// MarshalJSON renders the contained error as a JSON string.
+func (e *Error) MarshalJSON() ([]byte, error) {
+	if !e.Valid() {
+		return []byte(`"nil error"`), nil
+	}
+	return json.Marshal(e.Err.Error())
+}
+
+// UnmarshalJSON overwrites the contained error with a new plain string error.
+func (e *Error) UnmarshalJSON(b []byte) error {
+	if e == nil {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	e.Err = errors.New(s)
+	return nil
+}

--- a/api/error_test.go
+++ b/api/error_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestErrorJSON(t *testing.T) {
+	inStr := "hello, world!"
+	inErr := errors.New(inStr)
+
+	inError := NewError(inErr)
+
+	jsonBytes, err := json.Marshal(inError)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outError := NewError(nil)
+
+	err = json.Unmarshal(jsonBytes, outError)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// compare the very initial error to the
+	// marshalled-then-unmarshalled error
+	if want, have := inStr, outError.Error(); want != have {
+		t.Errorf("want: %v, have: %v", want, have)
+	}
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EnrollmentResults are the per-enrollment ID results of push or enqueue APIs.
+type EnrollmentResult struct {
+	// PushError is present if there was an error sending the APNs push notification.
+	PushError *Error `json:"push_error,omitempty"`
+
+	// PushID is the "apns-id" of a successful APNs push notification.
+	PushID string `json:"push_result,omitempty"`
+
+	// EnqueueError is present if there was an error enqueuing the command.
+	EnqueueError *Error `json:"command_error,omitempty"`
+}
+
+// APIResult is the result of push or enqueue APIs.
+type APIResult struct {
+	// Status is the per-enrollment ID results of push or enqueue APIs.
+	// Map key is the enrollment ID.
+	Status map[string]EnrollmentResult `json:"status,omitempty"`
+
+	// NoPush signifies if APNs pushes were not enabled for this API call.
+	NoPush bool `json:"no_push,omitempty"`
+
+	// PushError is present if there was an error sending the APNs push notifications.
+	PushError *Error `json:"push_error,omitempty"`
+
+	// EnqueueError is present if there was an error enqueuing the command.
+	EnqueueError *Error `json:"command_error,omitempty"`
+
+	CommandUUID string `json:"command_uuid,omitempty"` // CommandUUID of the enqueued command.
+	RequestType string `json:"request_type,omitempty"` // RequestType of the enqueued command.
+}
+
+// Error distills the APIResult errors to a simple error or returns nil.
+// If there are more than one error for an enrollment ID the last error is returned.
+// Error tries to preserve at least one "real" error by way of wrapping.
+func (r *APIResult) Error() error {
+	var errCt int
+	var statusErr error
+	var statusErrID string
+
+	for id, result := range r.Status {
+		if result.EnqueueError != nil {
+			errCt++
+			statusErr = fmt.Errorf("enqueue error: %w", result.EnqueueError)
+			statusErrID = id
+		} else if result.PushError != nil {
+			errCt++
+			statusErr = fmt.Errorf("push error: %w", result.PushError)
+			statusErrID = id
+		}
+	}
+
+	var errs []error
+
+	if r.EnqueueError != nil {
+		errs = append(errs, fmt.Errorf("enqueue error: %w", r.EnqueueError))
+	}
+
+	if r.PushError != nil {
+		errs = append(errs, fmt.Errorf("push error: %w", r.PushError))
+	}
+
+	if errCt > 0 {
+		errs = append(
+			errs,
+			fmt.Errorf("status errors (%d): last error for %s: %w", errCt, statusErrID, statusErr),
+		)
+	}
+
+	if len(errs) == 1 {
+		return errs[0]
+	} else if len(errs) > 1 {
+		var errStrs []string
+		for _, err := range errs {
+			errStrs = append(errStrs, err.Error())
+		}
+		return fmt.Errorf("%w; %s", errs[0], strings.Join(errStrs, "; "))
+	}
+
+	return nil
+}

--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/micromdm/nanomdm/service/multi"
 	"github.com/micromdm/nanomdm/service/nanomdm"
 
+	nlhttp "github.com/micromdm/nanolib/http"
+	"github.com/micromdm/nanolib/http/trace"
 	"github.com/micromdm/nanolib/log/stdlogfmt"
 )
 
@@ -40,9 +42,6 @@ const (
 
 	endpointAuthProxy = "/authproxy/"
 
-	endpointAPIPushCert  = "/v1/pushcert"
-	endpointAPIPush      = "/v1/push/"
-	endpointAPIEnqueue   = "/v1/enqueue/"
 	endpointAPIMigration = "/migration"
 	endpointAPIVersion   = "/version"
 )
@@ -136,6 +135,30 @@ func main() {
 	nano := nanomdm.New(mdmStorage, nanoOpts...)
 
 	mux := http.NewServeMux()
+	mdmAuthMux := mdmhttp.NewMWMux(mux)
+
+	if *flCertHeader != "" {
+		// extract certificate from HTTP header (mTLS)
+		mdmAuthMux.Use(func(h http.Handler) http.Handler {
+			return httpmdm.CertExtractPEMHeaderMiddleware(h, *flCertHeader, logger.With("handler", "cert-extract"))
+		})
+	} else {
+		opts := []httpmdm.SigLogOption{httpmdm.SigLogWithLogger(logger.With("handler", "cert-extract"))}
+
+		if *flDebug {
+			opts = append(opts, httpmdm.SigLogWithLogErrors(true))
+		}
+
+		// extract certificate from Mdm-Signature header
+		mdmAuthMux.Use(func(h http.Handler) http.Handler {
+			return httpmdm.CertExtractMdmSignatureMiddleware(h, httpmdm.MdmSignatureVerifierFunc(cryptoutil.VerifyMdmSignature), opts...)
+		})
+	}
+
+	// finally, verify the identity certificate
+	mdmAuthMux.Use(func(h http.Handler) http.Handler {
+		return httpmdm.CertVerifyMiddleware(h, verifier, logger.With("handler", "cert-verify"))
+	})
 
 	if !*flDisableMDM {
 		var mdmService service.CheckinAndCommandService = nano
@@ -152,87 +175,61 @@ func main() {
 			mdmService = dump.New(mdmService, os.Stdout)
 		}
 
-		// helper for authorizing MDM clients requests
-		certAuthMiddleware := func(h http.Handler) http.Handler {
-			h = httpmdm.CertVerifyMiddleware(h, verifier, logger.With("handler", "cert-verify"))
-			if *flCertHeader != "" {
-				h = httpmdm.CertExtractPEMHeaderMiddleware(h, *flCertHeader, logger.With("handler", "cert-extract"))
-			} else {
-				opts := []httpmdm.SigLogOption{httpmdm.SigLogWithLogger(logger.With("handler", "cert-extract"))}
-				if *flDebug {
-					opts = append(opts, httpmdm.SigLogWithLogErrors(true))
-				}
-				h = httpmdm.CertExtractMdmSignatureMiddleware(h, httpmdm.MdmSignatureVerifierFunc(cryptoutil.VerifyMdmSignature), opts...)
-			}
-			return h
-		}
-
-		// register 'core' MDM HTTP handler
-		var mdmHandler http.Handler
-		if *flCheckin {
-			// if we use the check-in handler then only handle commands
-			mdmHandler = httpmdm.CommandAndReportResultsHandler(mdmService, logger.With("handler", "command"))
-		} else {
-			// if we don't use a check-in handler then do both
-			mdmHandler = httpmdm.CheckinAndCommandHandler(mdmService, logger.With("handler", "checkin-command"))
-		}
-		mdmHandler = certAuthMiddleware(mdmHandler)
-		mux.Handle(endpointMDM, mdmHandler)
-
+		// register 'core' MDM HTTP handlers
 		if *flCheckin {
 			// if we specified a separate check-in handler, set it up
-			var checkinHandler http.Handler
-			checkinHandler = httpmdm.CheckinHandler(mdmService, logger.With("handler", "checkin"))
-			checkinHandler = certAuthMiddleware(checkinHandler)
-			mux.Handle(endpointCheckin, checkinHandler)
+			mdmAuthMux.Handle(endpointCheckin, httpmdm.CheckinHandler(mdmService, logger.With("handler", "checkin")))
+
+			// if we use the check-in handler then only handle commands
+			mdmAuthMux.Handle(endpointMDM, httpmdm.CommandAndReportResultsHandler(mdmService, logger.With("handler", "command")))
+		} else {
+			// if we don't use a check-in handler then do both
+			mdmAuthMux.Handle(endpointMDM, httpmdm.CheckinAndCommandHandler(mdmService, logger.With("handler", "checkin-command")))
 		}
 
 		if *flAuthProxy != "" {
-			var authProxyHandler http.Handler
-			authProxyHandler, err = authproxy.New(*flAuthProxy,
+			authProxy, err := authproxy.New(*flAuthProxy,
 				authproxy.WithLogger(logger.With("handler", "authproxy")),
 				authproxy.WithHeaderFunc(EnrollmentIDHeader, httpmdm.GetEnrollmentID),
-				authproxy.WithHeaderFunc(TraceIDHeader, mdmhttp.GetTraceID),
+				authproxy.WithHeaderFunc(TraceIDHeader, trace.GetTraceID),
 			)
 			if err != nil {
 				stdlog.Fatal(err)
 			}
+
+			apMux := mdmhttp.NewMWMux(mdmAuthMux)
+
+			// wrap with enrollment ID lookup middleware
+			apMux.Use(func(h http.Handler) http.Handler {
+				return httpmdm.CertWithEnrollmentIDMiddleware(
+					h,
+					certauth.HashCert,
+					mdmStorage,
+					true,
+					logger.With("handler", "with-enrollment-id"))
+			})
+
+			apMux.Handle(endpointAuthProxy, http.StripPrefix(endpointAuthProxy, authProxy))
+
 			logger.Debug("msg", "authproxy setup", "url", *flAuthProxy)
-			authProxyHandler = http.StripPrefix(endpointAuthProxy, authProxyHandler)
-			authProxyHandler = httpmdm.CertWithEnrollmentIDMiddleware(authProxyHandler, certauth.HashCert, mdmStorage, true, logger.With("handler", "with-enrollment-id"))
-			authProxyHandler = certAuthMiddleware(authProxyHandler)
-			mux.Handle(endpointAuthProxy, authProxyHandler)
 		}
 	}
 
 	if *flAPIKey != "" {
 		const apiUsername = "nanomdm"
 
+		apiAuthMux := mdmhttp.NewMWMux(mux)
+
+		apiAuthMux.Use(func(h http.Handler) http.Handler {
+			return nlhttp.NewSimpleBasicAuthHandler(h, apiUsername, *flAPIKey, "nanomdm")
+		})
+
 		// create our push provider and push service
 		pushProviderFactory := nanopush.NewFactory()
 		pushService := pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, logger.With("service", "push"))
 
-		// register API handler for push cert storage/upload.
-		var pushCertHandler http.Handler
-		pushCertHandler = httpapi.StorePushCertHandler(mdmStorage, logger.With("handler", "store-cert"))
-		pushCertHandler = mdmhttp.BasicAuthMiddleware(pushCertHandler, apiUsername, *flAPIKey, "nanomdm")
-		mux.Handle(endpointAPIPushCert, pushCertHandler)
-
-		// register API handler for push notifications.
-		// we strip the prefix to use the path as an id.
-		var pushHandler http.Handler
-		pushHandler = httpapi.PushHandler(pushService, logger.With("handler", "push"))
-		pushHandler = http.StripPrefix(endpointAPIPush, pushHandler)
-		pushHandler = mdmhttp.BasicAuthMiddleware(pushHandler, apiUsername, *flAPIKey, "nanomdm")
-		mux.Handle(endpointAPIPush, pushHandler)
-
-		// register API handler for new command queueing.
-		// we strip the prefix to use the path as an id.
-		var enqueueHandler http.Handler
-		enqueueHandler = httpapi.RawCommandEnqueueHandler(mdmStorage, pushService, logger.With("handler", "enqueue"))
-		enqueueHandler = http.StripPrefix(endpointAPIEnqueue, enqueueHandler)
-		enqueueHandler = mdmhttp.BasicAuthMiddleware(enqueueHandler, apiUsername, *flAPIKey, "nanomdm")
-		mux.Handle(endpointAPIEnqueue, enqueueHandler)
+		// register API handlers
+		httpapi.HandleAPIv1("/v1", apiAuthMux, logger, mdmStorage, pushService)
 
 		if *flMigration {
 			// setup a "migration" handler that takes Check-In messages
@@ -243,19 +240,19 @@ func main() {
 			// authenticate and tokenupdate message to effectively
 			// generate "enrollments" then this effively allows us to
 			// migrate MDM enrollments between servers.
-			var migHandler http.Handler
-			migHandler = httpmdm.CheckinHandler(nano, logger.With("handler", "migration"))
-			migHandler = mdmhttp.BasicAuthMiddleware(migHandler, apiUsername, *flAPIKey, "nanomdm")
-			mux.Handle(endpointAPIMigration, migHandler)
+			apiAuthMux.Handle(
+				endpointAPIMigration,
+				httpmdm.CheckinHandler(nano, logger.With("handler", "migration")),
+			)
 		}
 	}
 
-	mux.HandleFunc(endpointAPIVersion, mdmhttp.VersionHandler(version))
+	mux.HandleFunc(endpointAPIVersion, nlhttp.NewJSONVersionHandler(version))
 
 	rand.Seed(time.Now().UnixNano())
 
 	logger.Info("msg", "starting server", "listen", *flListen)
-	err = http.ListenAndServe(*flListen, mdmhttp.TraceLoggingMiddleware(mux, logger.With("handler", "log"), newTraceID))
+	err = http.ListenAndServe(*flListen, trace.NewTraceLoggingHandler(mux, logger.With("handler", "log"), newTraceID))
 	logs := []interface{}{"msg", "server shutdown"}
 	if err != nil {
 		logs = append(logs, "err", err)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -96,8 +96,6 @@ paths:
           $ref: '#/components/responses/APIResultOK'
         '207':
           $ref: '#/components/responses/APIResultSomeFailed'
-        '400':
-          description: Error decoding MDM command plist.
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '500':

--- a/http/api/api.go
+++ b/http/api/api.go
@@ -78,7 +78,8 @@ func PathIDGetter(r *http.Request) ([]string, error) {
 // note we expose Go errors to the output as this is meant for "API"
 // users.
 //
-// Deprecated: use [PushToIDsHandler].
+// Deprecated: use [PushToIDsHandler] instead.
+// Use [PathIDGetter] with it for the previous behavior.
 func PushHandler(pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 	return PushToIDsHandler(pusher, logger, PathIDGetter)
 }
@@ -143,7 +144,8 @@ func PushToIDsHandler(pusher push.Pusher, logger log.Logger, idGetter func(*http
 // using. Also note we expose Go errors to the output as this is meant
 // for "API" users.
 //
-// Deprecated: use [RawCommandEnqueueToIDsHandler].
+// Deprecated: use [RawCommandEnqueueToIDsHandler] instead.
+// Use [PathIDGetter] with it for the previous behavior.
 func RawCommandEnqueueHandler(enqueuer storage.CommandEnqueuer, pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 	return RawCommandEnqueueToIDsHandler(enqueuer, pusher, logger, PathIDGetter)
 }

--- a/http/api/api.go
+++ b/http/api/api.go
@@ -2,20 +2,20 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/micromdm/nanomdm/api"
 	"github.com/micromdm/nanomdm/cryptoutil"
 	mdmhttp "github.com/micromdm/nanomdm/http"
-	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/push"
 	"github.com/micromdm/nanomdm/storage"
 
@@ -23,54 +23,44 @@ import (
 	"github.com/micromdm/nanolib/log/ctxlog"
 )
 
-// enrolledAPIResult is a per-enrollment API result.
-type enrolledAPIResult struct {
-	PushError    string `json:"push_error,omitempty"`
-	PushResult   string `json:"push_result,omitempty"`
-	CommandError string `json:"command_error,omitempty"`
-}
-
-// enrolledAPIResults is a map of enrollments to a per-enrollment API result.
-type enrolledAPIResults map[string]*enrolledAPIResult
-
-// apiResult is the JSON reply returned from either pushing or queuing commands.
-type apiResult struct {
-	Status       enrolledAPIResults `json:"status,omitempty"`
-	NoPush       bool               `json:"no_push,omitempty"`
-	PushError    string             `json:"push_error,omitempty"`
-	CommandError string             `json:"command_error,omitempty"`
-	CommandUUID  string             `json:"command_uuid,omitempty"`
-	RequestType  string             `json:"request_type,omitempty"`
-}
-
-type (
-	ctxKeyIDFirst struct{}
-	ctxKeyIDCount struct{}
-)
-
-func setAPIIDs(ctx context.Context, idFirst string, idCount int) context.Context {
-	ctx = context.WithValue(ctx, ctxKeyIDFirst{}, idFirst)
-	return context.WithValue(ctx, ctxKeyIDCount{}, idCount)
-}
-
-func ctxKVs(ctx context.Context) (out []interface{}) {
-	id, ok := ctx.Value(ctxKeyIDFirst{}).(string)
-	if ok {
-		out = append(out, "id_first", id)
+// writeAPIResult encodes r to JSON to w, logging errors to logger if necessary.
+func writeAPIResult(logger log.Logger, w http.ResponseWriter, r *api.APIResult, header int) {
+	if header < 1 {
+		header = http.StatusInternalServerError
 	}
-	eType, ok := ctx.Value(ctxKeyIDCount{}).(int)
-	if ok {
-		out = append(out, "id_count", eType)
+
+	if r == nil {
+		nilErr := api.NewError(errors.New("nil API result"))
+		r = &api.APIResult{
+			EnqueueError: nilErr,
+			PushError:    nilErr,
+		}
 	}
-	return
+
+	w.Header().Set("Content-type", "application/json")
+	w.WriteHeader(header)
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "\t")
+
+	err := enc.Encode(r)
+	if err != nil && logger != nil {
+		logger.Info("msg", "encoding json", "err", err)
+	}
 }
 
-func setupCtxLog(ctx context.Context, ids []string, logger log.Logger) (context.Context, log.Logger) {
-	if len(ids) > 0 {
-		ctx = setAPIIDs(ctx, ids[0], len(ids))
-		ctx = ctxlog.AddFunc(ctx, ctxKVs)
+// amendAPIError amends or inserts err into e.
+func amendAPIError(err error, e **api.Error) {
+	if e == nil || err == nil {
+		return
 	}
-	return ctx, ctxlog.Logger(ctx, logger)
+	if *e == nil {
+		// add new
+		*e = api.NewError(err)
+	} else {
+		// amend any existing error
+		*e = api.NewError(fmt.Errorf("result API error: %w; previous error: %v", err, (*e).Err))
+	}
 }
 
 // PushHandler sends APNs push notifications to MDM enrollments.
@@ -83,55 +73,49 @@ func PushHandler(pusher push.Pusher, logger log.Logger) http.HandlerFunc {
 	if pusher == nil {
 		panic("nil pusher")
 	}
+
+	pe, peErr := api.NewPushEnqueuer(nil, pusher, api.WithLogger(logger))
+	if peErr != nil {
+		panic(peErr)
+	}
+
 	return func(w http.ResponseWriter, r *http.Request) {
-		ids := strings.Split(r.URL.Path, ",")
-		ctx, logger := setupCtxLog(r.Context(), ids, logger)
-		output := apiResult{
-			Status: make(enrolledAPIResults),
-		}
-		logs := []interface{}{"msg", "push"}
-		pushResp, err := pusher.Push(ctx, ids)
-		if err != nil {
-			logs = append(logs, "err", err)
-			output.PushError = err.Error()
-		}
-		var ct, errCt int
-		for id, resp := range pushResp {
-			output.Status[id] = &enrolledAPIResult{
-				PushResult: resp.Id,
-			}
-			if resp.Err != nil {
-				output.Status[id].PushError = resp.Err.Error()
-				errCt += 1
-			} else {
-				ct += 1
-			}
-		}
-		logs = append(logs, "count", ct)
-		if errCt > 0 {
-			logs = append(logs, "errs", errCt)
-		}
-		if err != nil || errCt > 0 {
-			logger.Info(logs...)
-		} else {
-			logger.Debug(logs...)
-		}
-		// generate response codes depending on if everything succeeded, failed, or parially succedded
+		var pr *api.APIResult
 		header := http.StatusInternalServerError
-		if (errCt > 0 || err != nil) && ct > 0 {
-			header = http.StatusMultiStatus
-		} else if (errCt == 0 && err == nil) && ct >= 1 {
-			header = http.StatusOK
+		logger := ctxlog.Logger(r.Context(), logger)
+
+		defer func() {
+			writeAPIResult(logger, w, pr, header)
+		}()
+
+		if r.URL.Path == "" {
+			err := errors.New("missing ids (in URL path)")
+			logger.Info("err", err)
+			// synthesize an API result error
+			er := new(api.APIResult)
+			amendAPIError(err, &er.PushError)
+			return
 		}
-		json, err := json.MarshalIndent(output, "", "\t")
+
+		ids := strings.Split(r.URL.Path, ",")
+
+		pr, header, err := pe.Push(r.Context(), ids)
 		if err != nil {
-			logger.Info("msg", "marshal json", "err", err)
-		}
-		w.Header().Set("Content-type", "application/json")
-		w.WriteHeader(header)
-		_, err = w.Write(json)
-		if err != nil {
-			logger.Info("msg", "writing body", "err", err)
+			if pr == nil {
+				pr = new(api.APIResult)
+			}
+			// amend the result json with our error
+			// so as to be visible to HTTP API callers
+			amendAPIError(err, &pr.PushError)
+			logs := []interface{}{
+				"msg", "sending push",
+				"id_count", len(ids),
+				"err", err,
+			}
+			if len(ids) > 0 {
+				logs = append(logs, "id_first", ids[0])
+			}
+			logger.Info(logs...)
 		}
 	}
 }
@@ -147,126 +131,59 @@ func RawCommandEnqueueHandler(enqueuer storage.CommandEnqueuer, pusher push.Push
 	if enqueuer == nil {
 		panic("nil enqueuer")
 	}
-	if logger == nil {
-		panic("nil logger")
+
+	pe, peErr := api.NewPushEnqueuer(enqueuer, pusher, api.WithLogger(logger))
+	if peErr != nil {
+		panic(peErr)
 	}
+
 	return func(w http.ResponseWriter, r *http.Request) {
-		ids := strings.Split(r.URL.Path, ",")
-		ctx, logger := setupCtxLog(r.Context(), ids, logger)
-		b, err := mdmhttp.ReadAllAndReplaceBody(r)
+		var er *api.APIResult
+		header := http.StatusInternalServerError
+		logger := ctxlog.Logger(r.Context(), logger)
+
+		defer func() {
+			writeAPIResult(logger, w, er, header)
+		}()
+
+		if r.URL.Path == "" {
+			err := errors.New("missing ids (in URL path)")
+			logger.Info("err", err)
+			// synthesize an API result error
+			er := new(api.APIResult)
+			amendAPIError(err, &er.EnqueueError)
+			return
+		}
+
+		cmdBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			logger.Info("msg", "reading body", "err", err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			// synthesize an API result error
+			er := new(api.APIResult)
+			amendAPIError(err, &er.EnqueueError)
 			return
 		}
-		command, err := mdm.DecodeCommand(b)
+
+		ids := strings.Split(r.URL.Path, ",")
+		noPush := r.URL.Query().Get("nopush") != ""
+
+		er, header, err = pe.RawCommandEnqueueWithPush(r.Context(), cmdBytes, ids, noPush)
 		if err != nil {
-			logger.Info("msg", "decoding command", "err", err)
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-			return
-		}
-		nopush := r.URL.Query().Get("nopush") != ""
-		output := apiResult{
-			Status:      make(enrolledAPIResults),
-			NoPush:      nopush,
-			CommandUUID: command.CommandUUID,
-			RequestType: command.Command.RequestType,
-		}
-		logger = logger.With(
-			"command_uuid", command.CommandUUID,
-			"request_type", command.Command.RequestType,
-		)
-		logs := []interface{}{
-			"msg", "enqueue",
-		}
-		idErrs, err := enqueuer.EnqueueCommand(ctx, ids, command)
-		ct := len(ids) - len(idErrs)
-		if err != nil {
-			logs = append(logs, "err", err)
-			output.CommandError = err.Error()
-			if len(idErrs) == 0 {
-				// we assume if there were no ID-specific errors but
-				// there was a general error then all IDs failed
-				ct = 0
+			if er == nil {
+				er = new(api.APIResult)
 			}
-		}
-		logs = append(logs, "count", ct)
-		if len(idErrs) > 0 {
-			logs = append(logs, "errs", len(idErrs))
-		}
-		if err != nil || len(idErrs) > 0 {
+			// amend the result json with our error
+			// so as to be visible to HTTP API callers
+			amendAPIError(err, &er.EnqueueError)
+			logs := []interface{}{
+				"msg", "enqueueing",
+				"id_count", len(ids),
+				"err", err,
+			}
+			if len(ids) > 0 {
+				logs = append(logs, "id_first", ids[0])
+			}
 			logger.Info(logs...)
-		} else {
-			logger.Debug(logs...)
-		}
-		// loop through our command errors, if any, and add to output
-		for id, err := range idErrs {
-			if err != nil {
-				output.Status[id] = &enrolledAPIResult{
-					CommandError: err.Error(),
-				}
-			}
-		}
-		// optionally send pushes
-		pushResp := make(map[string]*push.Response)
-		var pushErr error
-		if !nopush && pusher != nil {
-			pushResp, pushErr = pusher.Push(ctx, ids)
-			if err != nil {
-				logger.Info("msg", "push", "err", err)
-				output.PushError = err.Error()
-			}
-		} else if !nopush && pusher == nil {
-			pushErr = errors.New("nil pusher")
-		}
-		// loop through our push errors, if any, and add to output
-		var pushCt, pushErrCt int
-		for id, resp := range pushResp {
-			if _, ok := output.Status[id]; ok {
-				output.Status[id].PushResult = resp.Id
-			} else {
-				output.Status[id] = &enrolledAPIResult{
-					PushResult: resp.Id,
-				}
-			}
-			if resp.Err != nil {
-				output.Status[id].PushError = resp.Err.Error()
-				pushErrCt++
-			} else {
-				pushCt++
-			}
-		}
-		logs = []interface{}{
-			"msg", "push",
-			"count", pushCt,
-		}
-		if pushErr != nil {
-			logs = append(logs, "err", pushErr)
-		}
-		if pushErrCt > 0 {
-			logs = append(logs, "errs", pushErrCt)
-		}
-		if pushErr != nil || pushErrCt > 0 {
-			logger.Info(logs...)
-		} else {
-			logger.Debug(logs...)
-		}
-		// generate response codes depending on if everything succeeded, failed, or parially succedded
-		header := http.StatusInternalServerError
-		if (len(idErrs) > 0 || err != nil || (!nopush && (pushErrCt > 0 || pushErr != nil))) && (ct > 0 || (!nopush && (pushCt > 0))) {
-			header = http.StatusMultiStatus
-		} else if (len(idErrs) == 0 && err == nil && (nopush || (pushErrCt == 0 && pushErr == nil))) && (ct >= 1 && (nopush || (pushCt >= 1))) {
-			header = http.StatusOK
-		}
-		json, err := json.MarshalIndent(output, "", "\t")
-		if err != nil {
-			logger.Info("msg", "marshal json", "err", err)
-		}
-		w.Header().Set("Content-type", "application/json")
-		w.WriteHeader(header)
-		_, err = w.Write(json)
-		if err != nil {
-			logger.Info("msg", "writing body", "err", err)
 		}
 	}
 }

--- a/http/api/v1.go
+++ b/http/api/v1.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/micromdm/nanomdm/push"
+	"github.com/micromdm/nanomdm/storage"
+
+	"github.com/micromdm/nanolib/log"
+)
+
+const (
+	APIEndpointPushCert = "/pushcert"
+	APIEndpointPush     = "/push/"    // note trailing slash
+	APIEndpointEnqueue  = "/enqueue/" // note trailing slash
+)
+
+// Mux can register HTTP handlers.
+type Mux interface {
+	// Handle registers the handler for the given pattern.
+	// It is assumed pattern operates similar to http.ServeMux with
+	// respect to "trailing slash" behavior.
+	Handle(pattern string, handler http.Handler)
+}
+
+// APIStorage is required for the API handlers.
+type APIStorage interface {
+	storage.PushCertStore
+	storage.CommandEnqueuer
+}
+
+func handlerName(endpoint string) string {
+	return strings.Trim(endpoint, "/")
+}
+
+// HandleAPIv1 registers the various API handlers into mux.
+// API endpoint paths are prepended with prefix.
+// Authentication or any other layered handlers are not present.
+// They are assumed to be layered with mux.
+// If prefix is empty and these handlers are used in sub-paths then
+// handlers should have that sub-path stripped from the request.
+// The logger is adorned with a "handler" key of the endpoint name.
+func HandleAPIv1(prefix string, mux Mux, logger log.Logger, store APIStorage, pusher push.Pusher) {
+	// register API handler for push cert storage/upload
+	mux.Handle(
+		prefix+APIEndpointPushCert,
+		StorePushCertHandler(
+			store,
+			logger.With("handler", handlerName(APIEndpointPushCert)),
+		),
+	)
+
+	// register API handler for sending APNs push notifications
+	if pusher != nil {
+		mux.Handle(
+			prefix+APIEndpointPush,
+			http.StripPrefix( // we strip the prefix to use the path as an id
+				prefix+APIEndpointPush,
+				PushHandler(
+					pusher,
+					logger.With("handler", handlerName(APIEndpointPush)),
+				),
+			),
+		)
+	}
+
+	// register API handler for new command enqueueing
+	mux.Handle(
+		prefix+APIEndpointEnqueue,
+		http.StripPrefix( // we strip the prefix to use the path as an id
+			prefix+APIEndpointEnqueue,
+			RawCommandEnqueueHandler(
+				store,
+				pusher,
+				logger.With("handler", handlerName(APIEndpointEnqueue)),
+			),
+		),
+	)
+}

--- a/http/http.go
+++ b/http/http.go
@@ -3,15 +3,9 @@ package http
 
 import (
 	"bytes"
-	"context"
-	"crypto/subtle"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
-
-	"github.com/micromdm/nanolib/log"
-	"github.com/micromdm/nanolib/log/ctxlog"
 )
 
 // ReadAllAndReplaceBody reads all of r.Body and replaces it with a new byte buffer.
@@ -23,67 +17,4 @@ func ReadAllAndReplaceBody(r *http.Request) ([]byte, error) {
 	defer r.Body.Close()
 	r.Body = io.NopCloser(bytes.NewBuffer(b))
 	return b, nil
-}
-
-// BasicAuthMiddleware is a simple HTTP plain authentication middleware.
-func BasicAuthMiddleware(next http.Handler, username, password, realm string) http.HandlerFunc {
-	uBytes := []byte(username)
-	pBytes := []byte(password)
-	return func(w http.ResponseWriter, r *http.Request) {
-		u, p, ok := r.BasicAuth()
-		if !ok || subtle.ConstantTimeCompare([]byte(u), uBytes) != 1 || subtle.ConstantTimeCompare([]byte(p), pBytes) != 1 {
-			w.Header().Set("WWW-Authenticate", `Basic realm="`+realm+`"`)
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r)
-	}
-}
-
-// VersionHandler returns a simple JSON response from a version string.
-func VersionHandler(version string) http.HandlerFunc {
-	bodyBytes := []byte(`{"version":"` + version + `"}`)
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(bodyBytes)
-	}
-}
-
-type ctxKeyTraceID struct{}
-
-// GetTraceID returns the trace ID from ctx.
-func GetTraceID(ctx context.Context) string {
-	id, _ := ctx.Value(ctxKeyTraceID{}).(string)
-	return id
-}
-
-// TraceLoggingMiddleware sets up a trace ID in the request context and
-// logs HTTP requests.
-func TraceLoggingMiddleware(next http.Handler, logger log.Logger, traceID func(*http.Request) string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		if traceID != nil {
-			ctx = context.WithValue(r.Context(), ctxKeyTraceID{}, traceID(r))
-			ctx = ctxlog.AddFunc(ctx, ctxlog.SimpleStringFunc("trace_id", ctxKeyTraceID{}))
-		}
-
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			host = r.RemoteAddr
-		}
-		logs := []interface{}{
-			"addr", host,
-			"method", r.Method,
-			"path", r.URL.Path,
-			"agent", r.UserAgent(),
-		}
-
-		if fwdedFor := r.Header.Get("X-Forwarded-For"); fwdedFor != "" {
-			logs = append(logs, "x_forwarded_for", fwdedFor)
-		}
-
-		ctxlog.Logger(ctx, logger).Info(logs...)
-
-		next.ServeHTTP(w, r.WithContext(ctx))
-	}
 }

--- a/http/mwmux.go
+++ b/http/mwmux.go
@@ -1,0 +1,56 @@
+package http
+
+import (
+	"net/http"
+	"sync"
+)
+
+// Mux represents an HTTP muxer that can handle HTTP methods.
+type Mux interface {
+	Handle(pattern string, handler http.Handler)
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}
+
+// MWMux applies middleware when registering HTTP handlers.
+type MWMux struct {
+	mux Mux
+
+	middlewares []func(http.Handler) http.Handler
+	mu          sync.RWMutex
+}
+
+// NewMWMux creates a new MWMux using mux.
+func NewMWMux(mux Mux) *MWMux {
+	return &MWMux{mux: mux}
+}
+
+// Use adds middlewares to be applied when registering HTTP handlers.
+func (m *MWMux) Use(middlewares ...func(http.Handler) http.Handler) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.middlewares = append(m.middlewares, middlewares...)
+}
+
+// Handle layers middlewares around handler and registers them with pattern.
+func (m *MWMux) Handle(pattern string, handler http.Handler) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// assemble middleware in descending order
+	for i := len(m.middlewares) - 1; i >= 0; i-- {
+		handler = m.middlewares[i](handler)
+	}
+
+	m.mux.Handle(pattern, handler)
+}
+
+// HandleFunc layers middlewares around handler and registers them with pattern.
+func (m *MWMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	m.Handle(pattern, http.HandlerFunc(handler))
+}
+
+// ServeHTTP is a convenience wrapper to use m itself as an HTTP handler.
+func (m *MWMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.mux.ServeHTTP(w, r)
+}

--- a/mdm/command.go
+++ b/mdm/command.go
@@ -9,6 +9,7 @@ import (
 var (
 	ErrInvalidCommandResult = errors.New("invalid command result")
 	ErrInvalidCommand       = errors.New("invalid command")
+	ErrEmptyCommand         = errors.New("empty command bytes")
 )
 
 // ErrorChain represents errors that occured on the client executing an MDM command.
@@ -54,6 +55,9 @@ type Command struct {
 
 // DecodeCommand unmarshals rawCommand into command
 func DecodeCommand(rawCommand []byte) (command *Command, err error) {
+	if len(rawCommand) < 1 {
+		return nil, ErrEmptyCommand
+	}
 	command = new(Command)
 	err = plist.Unmarshal(rawCommand, command)
 	if err != nil {

--- a/test/e2e/api.go
+++ b/test/e2e/api.go
@@ -21,6 +21,7 @@ type Doer interface {
 type api struct {
 	doer        Doer
 	urlPushCert string
+	urlEnqueue  string
 }
 
 func (a *api) PushCert(ctx context.Context, pemCert, pemKey []byte) error {
@@ -52,11 +53,11 @@ func (a *api) RawCommandEnqueue(ctx context.Context, ids []string, cmd *mdm.Comm
 		return err
 	}
 
-	if !strings.HasSuffix(enqueueURL, "/") {
+	if !strings.HasSuffix(a.urlEnqueue, "/") {
 		return errors.New("missing trailing slash of enqueue URL")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, enqueueURL+strings.Join(ids, ","), r)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.urlEnqueue+strings.Join(ids, ","), r)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -25,7 +25,7 @@ const (
 )
 
 // setupNanoMDM configures normal-ish NanoMDM HTTP server handlers for testing.
-func setupNanoMDM(logger log.Logger, store storage.AllStorage) (http.Handler, error) {
+func setupNanoMDM(serverURL string, logger log.Logger, store storage.AllStorage) (http.Handler, error) {
 	// begin with the primary NanoMDM service
 	var svc service.CheckinAndCommandService = nanomdm.New(store, nanomdm.WithLogger(logger))
 
@@ -61,7 +61,7 @@ type IDer interface {
 func TestE2E(t *testing.T, ctx context.Context, store storage.AllStorage) {
 	var logger log.Logger = log.NopLogger // stdlogfmt.New(stdlogfmt.WithDebugFlag(true))
 
-	mux, err := setupNanoMDM(logger, store)
+	mux, err := setupNanoMDM(serverURL, logger, store)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestE2E(t *testing.T, ctx context.Context, store storage.AllStorage) {
 		}
 	})
 
-	t.Run("queue", func(t *testing.T) { queue(t, ctx, d, &api{doer: c}, store) })
+	t.Run("queue", func(t *testing.T) { queue(t, ctx, d, &api{doer: c, urlEnqueue: enqueueURL}, store) })
 
 	t.Run("migrate", func(t *testing.T) { migrate(t, ctx, store, d) })
 }

--- a/test/e2e/pushcert.go
+++ b/test/e2e/pushcert.go
@@ -13,7 +13,11 @@ import (
 	"github.com/micromdm/nanomdm/test"
 )
 
-func pushcert(t *testing.T, ctx context.Context, store storage.PushCertStore) {
+type pushCertUploader interface {
+	PushCert(ctx context.Context, pemCert, pemKey []byte) error
+}
+
+func pushcert(t *testing.T, ctx context.Context, a pushCertUploader, store storage.PushCertStore) {
 	pemCert, err := os.ReadFile("../../test/e2e/testdata/push.pem")
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +45,7 @@ func pushcert(t *testing.T, ctx context.Context, store storage.PushCertStore) {
 		t.Fatal(err)
 	}
 
-	err = store.StorePushCert(ctx, pemCert, pemKey)
+	err = a.PushCert(ctx, pemCert, pemKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -10,6 +10,11 @@ import (
 	"github.com/micromdm/nanomdm/storage"
 )
 
+type enqueuer interface {
+	// RawCommandEnqueue enqueues cmd to ids. An APNs push is omitted if nopush is true.
+	RawCommandEnqueue(ctx context.Context, ids []string, cmd *mdm.Command, nopush bool) error
+}
+
 type queueDevice interface {
 	CMDDoReportAndFetch(ctx context.Context, cmd *mdm.CommandResults) (*mdm.Command, error)
 	NewCommandReport(uuid, status string, errors []mdm.ErrorChain) *mdm.CommandResults
@@ -18,7 +23,7 @@ type queueDevice interface {
 }
 
 // enqueue enqueues cmd to id using a.
-func enqueue(t *testing.T, ctx context.Context, a NanoMDMAPI, id string, cmd *mdm.Command) {
+func enqueue(t *testing.T, ctx context.Context, a enqueuer, id string, cmd *mdm.Command) {
 	t.Helper()
 	err := a.RawCommandEnqueue(ctx, []string{id}, cmd, true)
 	if err != nil {
@@ -46,13 +51,13 @@ func sendReportExpectCommandReply(t *testing.T, ctx context.Context, d queueDevi
 }
 
 // enqueueSimple enqueues cmd to a for d.
-func enqueueSimple(t *testing.T, ctx context.Context, d queueDevice, a NanoMDMAPI, cmd string) {
+func enqueueSimple(t *testing.T, ctx context.Context, d queueDevice, a enqueuer, cmd string) {
 	t.Helper()
 	// we're assuming the UDID is all we need here.
 	enqueue(t, ctx, a, d.ID(), simpleCmd(cmd))
 }
 
-func queue(t *testing.T, ctx context.Context, d queueDevice, a NanoMDMAPI, s storage.CommandAndReportResultsStore) {
+func queue(t *testing.T, ctx context.Context, d queueDevice, a enqueuer, s storage.CommandAndReportResultsStore) {
 	t.Run("basic", func(t *testing.T) {
 		// report Idle.
 		// expect no command (empty queue for this id).


### PR DESCRIPTION
- New `api` Go package that abstracts enqueueing commands and sending APNs notifications.
  - Refactor push and enqueue API HTTP handlers to use the new package.
- Refactor HTTP muxers to utilize a typical Go HTTP middleware style.
  - Both in main NanoMDM command and e2e tests.
- Abstract API handler attachment into helper function.
- Switch to NanoLIB implementations of common HTTP handlers.
