### PR TITLE
immutable context on mdm request

### DIFF
--- a/http/mdm/mdm.go
+++ b/http/mdm/mdm.go
@@ -14,17 +14,16 @@ import (
 	"github.com/micromdm/nanolib/log/ctxlog"
 )
 
-func mdmReqFromHTTPReq(r *http.Request) *mdm.Request {
-	values := r.URL.Query()
-	params := make(map[string]string, len(values))
-	for k, v := range values {
-		params[k] = v[0]
+// RequestFromHTTP adapts r to an MDM request.
+func RequestFromHTTP(r *http.Request) *mdm.Request {
+	m := mdm.NewRequestWithContext(r.Context(), GetCert(r.Context()))
+	if q := r.URL.Query(); len(q) > 0 {
+		m.Params = make(map[string]string, len(q))
+		for k, v := range q {
+			m.Params[k] = v[0]
+		}
 	}
-	return &mdm.Request{
-		Context:     r.Context(),
-		Certificate: GetCert(r.Context()),
-		Params:      params,
-	}
+	return m
 }
 
 // CheckinHandler decodes an MDM check-in request and adapts it to service.
@@ -43,7 +42,7 @@ func CheckinHandler(svc service.Checkin, logger log.Logger) http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		respBytes, err := service.CheckinRequest(svc, mdmReqFromHTTPReq(r), bodyBytes)
+		respBytes, err := service.CheckinRequest(svc, RequestFromHTTP(r), bodyBytes)
 		if err != nil {
 			logs := []interface{}{"msg", "check-in request"}
 			httpStatus := http.StatusInternalServerError
@@ -76,7 +75,7 @@ func CommandAndReportResultsHandler(svc service.CommandAndReportResults, logger 
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		respBytes, err := service.CommandAndReportResultsRequest(svc, mdmReqFromHTTPReq(r), bodyBytes)
+		respBytes, err := service.CommandAndReportResultsRequest(svc, RequestFromHTTP(r), bodyBytes)
 		if err != nil {
 			logs := []interface{}{"msg", "command report results"}
 			httpStatus := http.StatusInternalServerError

--- a/mdm/mdm.go
+++ b/mdm/mdm.go
@@ -50,14 +50,33 @@ func (eid *EnrollID) Validate() error {
 type Request struct {
 	*EnrollID
 	Certificate *x509.Certificate
-	Context     context.Context
 	Params      map[string]string
+	ctx         context.Context
 }
 
-// Clone returns a shallow copy of r
-func (r *Request) Clone() *Request {
+// NewRequestWithContext creates a new [Request] with ctx and cert.
+func NewRequestWithContext(ctx context.Context, cert *x509.Certificate) *Request {
+	return &Request{ctx: ctx, Certificate: cert}
+}
+
+// Context returns the request's context. To change the context use [Request.WithContext].
+// The returned context is always non-nil; it defaults to the background context.
+func (r *Request) Context() context.Context {
+	if r.ctx != nil {
+		return r.ctx
+	}
+	return context.Background()
+}
+
+// WithContext returns a shallow copy of r with its context changed to ctx.
+// The provided ctx must be non-nil.
+func (r *Request) WithContext(ctx context.Context) *Request {
+	if ctx == nil {
+		panic("nil context")
+	}
 	r2 := new(Request)
 	*r2 = *r
+	r2.ctx = ctx
 	return r2
 }
 

--- a/service/certauth/certauth.go
+++ b/service/certauth/certauth.go
@@ -117,7 +117,7 @@ func (s *CertAuth) associateNewEnrollment(r *mdm.Request) error {
 	if err := r.EnrollID.Validate(); err != nil {
 		return err
 	}
-	logger := ctxlog.Logger(r.Context, s.logger)
+	logger := ctxlog.Logger(r.Context(), s.logger)
 	hash := HashCert(r.Certificate)
 	if hasHash, err := s.storage.HasCertHash(r, hash); err != nil {
 		return err
@@ -162,7 +162,7 @@ func (s *CertAuth) validateAssociateExistingEnrollment(r *mdm.Request) error {
 	if err := r.EnrollID.Validate(); err != nil {
 		return err
 	}
-	logger := ctxlog.Logger(r.Context, s.logger)
+	logger := ctxlog.Logger(r.Context(), s.logger)
 	hash := HashCert(r.Certificate)
 	if isAssoc, err := s.storage.IsCertHashAssociated(r, hash); err != nil {
 		return err
@@ -230,7 +230,7 @@ func (s *CertAuth) validateAssociateExistingEnrollment(r *mdm.Request) error {
 }
 
 func (s *CertAuth) associateForNewEnrollment(r *mdm.Request, e *mdm.Enrollment) error {
-	req := r.Clone()
+	req := r.WithContext(r.Context())
 	req.EnrollID = s.normalizer(e)
 	if err := s.associateNewEnrollment(req); err != nil {
 		return fmt.Errorf("cert auth: new enrollment: %w", err)
@@ -239,7 +239,7 @@ func (s *CertAuth) associateForNewEnrollment(r *mdm.Request, e *mdm.Enrollment) 
 }
 
 func (s *CertAuth) validateOrAssociateForExistingEnrollment(r *mdm.Request, e *mdm.Enrollment) error {
-	req := r.Clone()
+	req := r.WithContext(r.Context())
 	req.EnrollID = s.normalizer(e)
 	if err := s.validateAssociateExistingEnrollment(req); err != nil {
 		return fmt.Errorf("cert auth: existing enrollment: %w", err)

--- a/service/microwebhook/service.go
+++ b/service/microwebhook/service.go
@@ -34,7 +34,7 @@ func (w *MicroWebhook) Authenticate(r *mdm.Request, m *mdm.Authenticate) error {
 			Params:       r.Params,
 		},
 	}
-	return postWebhookEvent(r.Context, w.client, w.url, ev)
+	return postWebhookEvent(r.Context(), w.client, w.url, ev)
 }
 
 func (w *MicroWebhook) TokenUpdate(r *mdm.Request, m *mdm.TokenUpdate) error {
@@ -49,13 +49,13 @@ func (w *MicroWebhook) TokenUpdate(r *mdm.Request, m *mdm.TokenUpdate) error {
 		},
 	}
 	if w.store != nil {
-		tally, err := w.store.RetrieveTokenUpdateTally(r.Context, r.ID)
+		tally, err := w.store.RetrieveTokenUpdateTally(r.Context(), r.ID)
 		if err != nil {
 			return err
 		}
 		ev.CheckinEvent.TokenUpdateTally = &tally
 	}
-	return postWebhookEvent(r.Context, w.client, w.url, ev)
+	return postWebhookEvent(r.Context(), w.client, w.url, ev)
 }
 
 func (w *MicroWebhook) CheckOut(r *mdm.Request, m *mdm.CheckOut) error {
@@ -69,7 +69,7 @@ func (w *MicroWebhook) CheckOut(r *mdm.Request, m *mdm.CheckOut) error {
 			Params:       r.Params,
 		},
 	}
-	return postWebhookEvent(r.Context, w.client, w.url, ev)
+	return postWebhookEvent(r.Context(), w.client, w.url, ev)
 }
 
 func (w *MicroWebhook) UserAuthenticate(r *mdm.Request, m *mdm.UserAuthenticate) ([]byte, error) {
@@ -83,7 +83,7 @@ func (w *MicroWebhook) UserAuthenticate(r *mdm.Request, m *mdm.UserAuthenticate)
 			Params:       r.Params,
 		},
 	}
-	return nil, postWebhookEvent(r.Context, w.client, w.url, ev)
+	return nil, postWebhookEvent(r.Context(), w.client, w.url, ev)
 }
 
 func (w *MicroWebhook) SetBootstrapToken(r *mdm.Request, m *mdm.SetBootstrapToken) error {
@@ -97,7 +97,7 @@ func (w *MicroWebhook) SetBootstrapToken(r *mdm.Request, m *mdm.SetBootstrapToke
 			Params:       r.Params,
 		},
 	}
-	return postWebhookEvent(r.Context, w.client, w.url, ev)
+	return postWebhookEvent(r.Context(), w.client, w.url, ev)
 }
 
 func (w *MicroWebhook) GetBootstrapToken(r *mdm.Request, m *mdm.GetBootstrapToken) (*mdm.BootstrapToken, error) {
@@ -111,7 +111,7 @@ func (w *MicroWebhook) GetBootstrapToken(r *mdm.Request, m *mdm.GetBootstrapToke
 			Params:       r.Params,
 		},
 	}
-	return nil, postWebhookEvent(r.Context, w.client, w.url, ev)
+	return nil, postWebhookEvent(r.Context(), w.client, w.url, ev)
 }
 
 func (w *MicroWebhook) CommandAndReportResults(r *mdm.Request, results *mdm.CommandResults) (*mdm.Command, error) {
@@ -127,7 +127,7 @@ func (w *MicroWebhook) CommandAndReportResults(r *mdm.Request, results *mdm.Comm
 			Params:       r.Params,
 		},
 	}
-	return nil, postWebhookEvent(r.Context, w.client, w.url, ev)
+	return nil, postWebhookEvent(r.Context(), w.client, w.url, ev)
 }
 
 func (w *MicroWebhook) DeclarativeManagement(r *mdm.Request, m *mdm.DeclarativeManagement) ([]byte, error) {
@@ -141,7 +141,7 @@ func (w *MicroWebhook) DeclarativeManagement(r *mdm.Request, m *mdm.DeclarativeM
 			Params:       r.Params,
 		},
 	}
-	return nil, postWebhookEvent(r.Context, w.client, w.url, ev)
+	return nil, postWebhookEvent(r.Context(), w.client, w.url, ev)
 }
 
 func (w *MicroWebhook) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetTokenResponse, error) {
@@ -155,5 +155,5 @@ func (w *MicroWebhook) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetTokenR
 			Params:       r.Params,
 		},
 	}
-	return nil, postWebhookEvent(r.Context, w.client, w.url, ev)
+	return nil, postWebhookEvent(r.Context(), w.client, w.url, ev)
 }

--- a/service/multi/context_test.go
+++ b/service/multi/context_test.go
@@ -20,7 +20,7 @@ type testSvc struct {
 }
 
 func (ts *testSvc) Authenticate(r *mdm.Request, _ *mdm.Authenticate) error {
-	ts.capture, _ = r.Context.Value(&ctxTest1{}).(string)
+	ts.capture, _ = r.Context().Value(&ctxTest1{}).(string)
 	ts.wg.Done()
 	return nil
 }
@@ -32,7 +32,7 @@ func TestContextPassthru(t *testing.T) {
 
 	ctx = context.WithValue(ctx, &ctxTest1{}, "test-ctx-val")
 
-	r := &mdm.Request{Context: ctx}
+	r := mdm.NewRequestWithContext(ctx, nil)
 
 	var wg sync.WaitGroup
 

--- a/service/multi/multi.go
+++ b/service/multi/multi.go
@@ -49,15 +49,13 @@ func (ms *MultiService) runOthers(ctx context.Context, r errorRunner) {
 
 // RequestWithContext returns a clone of r and sets its context to ctx.
 func (ms *MultiService) RequestWithContext(r *mdm.Request) *mdm.Request {
-	r2 := r.Clone()
-	r2.Context = ContextWithoutCancel(r.Context)
-	return r2
+	return r.WithContext(ContextWithoutCancel(r.Context()))
 }
 
 func (ms *MultiService) Authenticate(r *mdm.Request, m *mdm.Authenticate) error {
 	err := ms.svcs[0].Authenticate(r, m)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		return svc.Authenticate(rc, m)
 	})
 	return err
@@ -66,7 +64,7 @@ func (ms *MultiService) Authenticate(r *mdm.Request, m *mdm.Authenticate) error 
 func (ms *MultiService) TokenUpdate(r *mdm.Request, m *mdm.TokenUpdate) error {
 	err := ms.svcs[0].TokenUpdate(r, m)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		return svc.TokenUpdate(rc, m)
 	})
 	return err
@@ -75,7 +73,7 @@ func (ms *MultiService) TokenUpdate(r *mdm.Request, m *mdm.TokenUpdate) error {
 func (ms *MultiService) CheckOut(r *mdm.Request, m *mdm.CheckOut) error {
 	err := ms.svcs[0].CheckOut(r, m)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		return svc.CheckOut(rc, m)
 	})
 	return err
@@ -84,7 +82,7 @@ func (ms *MultiService) CheckOut(r *mdm.Request, m *mdm.CheckOut) error {
 func (ms *MultiService) UserAuthenticate(r *mdm.Request, m *mdm.UserAuthenticate) ([]byte, error) {
 	respBytes, err := ms.svcs[0].UserAuthenticate(r, m)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		_, err := svc.UserAuthenticate(rc, m)
 		return err
 	})
@@ -94,7 +92,7 @@ func (ms *MultiService) UserAuthenticate(r *mdm.Request, m *mdm.UserAuthenticate
 func (ms *MultiService) SetBootstrapToken(r *mdm.Request, m *mdm.SetBootstrapToken) error {
 	err := ms.svcs[0].SetBootstrapToken(r, m)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		return svc.SetBootstrapToken(rc, m)
 	})
 	return err
@@ -103,7 +101,7 @@ func (ms *MultiService) SetBootstrapToken(r *mdm.Request, m *mdm.SetBootstrapTok
 func (ms *MultiService) GetBootstrapToken(r *mdm.Request, m *mdm.GetBootstrapToken) (*mdm.BootstrapToken, error) {
 	bsToken, err := ms.svcs[0].GetBootstrapToken(r, m)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		_, err := svc.GetBootstrapToken(rc, m)
 		return err
 	})
@@ -113,7 +111,7 @@ func (ms *MultiService) GetBootstrapToken(r *mdm.Request, m *mdm.GetBootstrapTok
 func (ms *MultiService) DeclarativeManagement(r *mdm.Request, m *mdm.DeclarativeManagement) ([]byte, error) {
 	retBytes, err := ms.svcs[0].DeclarativeManagement(r, m)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		_, err := svc.DeclarativeManagement(rc, m)
 		return err
 	})
@@ -123,7 +121,7 @@ func (ms *MultiService) DeclarativeManagement(r *mdm.Request, m *mdm.Declarative
 func (ms *MultiService) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetTokenResponse, error) {
 	resp, err := ms.svcs[0].GetToken(r, m)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		_, err := svc.GetToken(rc, m)
 		return err
 	})
@@ -133,7 +131,7 @@ func (ms *MultiService) GetToken(r *mdm.Request, m *mdm.GetToken) (*mdm.GetToken
 func (ms *MultiService) CommandAndReportResults(r *mdm.Request, results *mdm.CommandResults) (*mdm.Command, error) {
 	cmd, err := ms.svcs[0].CommandAndReportResults(r, results)
 	rc := ms.RequestWithContext(r)
-	ms.runOthers(r.Context, func(svc service.CheckinAndCommandService) error {
+	ms.runOthers(r.Context(), func(svc service.CheckinAndCommandService) error {
 		_, err := svc.CommandAndReportResults(rc, results)
 		return err
 	})

--- a/service/nanomdm/dm.go
+++ b/service/nanomdm/dm.go
@@ -39,7 +39,7 @@ func (c *DeclarativeManagementHTTPCaller) DeclarativeManagement(r *mdm.Request, 
 	if len(message.Data) > 0 {
 		method = http.MethodPut
 	}
-	req, err := http.NewRequestWithContext(r.Context, method, u.String(), bytes.NewBuffer(message.Data))
+	req, err := http.NewRequestWithContext(r.Context(), method, u.String(), bytes.NewBuffer(message.Data))
 	if err != nil {
 		return nil, err
 	}

--- a/service/nanomdm/token_test.go
+++ b/service/nanomdm/token_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newTokenMDMReq() *mdm.Request {
-	return &mdm.Request{Context: context.Background()}
+	return mdm.NewRequestWithContext(context.Background(), nil)
 }
 
 const tokenTestCheckin = `<?xml version="1.0" encoding="UTF-8"?>

--- a/service/nanomdm/ua.go
+++ b/service/nanomdm/ua.go
@@ -52,7 +52,7 @@ var emptyDigestChallengeBytes = []byte(emptyDigestChallenge)
 // for the empty digest 2-step UserAuthenticate protocol.
 // It implements the NanoMDM service method for UserAuthenticate check-in messages.
 func (s *UAService) UserAuthenticate(r *mdm.Request, message *mdm.UserAuthenticate) ([]byte, error) {
-	logger := ctxlog.Logger(r.Context, s.logger)
+	logger := ctxlog.Logger(r.Context(), s.logger)
 	if s.sendEmptyDigestChallenge || s.storeRejectedUserAuth {
 		if err := s.store.StoreUserAuthenticate(r, message); err != nil {
 			return nil, err

--- a/storage/allmulti/allmulti.go
+++ b/storage/allmulti/allmulti.go
@@ -64,14 +64,14 @@ func (ms *MultiAllStorage) execStores(ctx context.Context, r errRunner) (interfa
 }
 
 func (ms *MultiAllStorage) StoreAuthenticate(r *mdm.Request, msg *mdm.Authenticate) error {
-	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreAuthenticate(r, msg)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) StoreTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate) error {
-	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreTokenUpdate(r, msg)
 	})
 	return err
@@ -85,14 +85,14 @@ func (ms *MultiAllStorage) RetrieveTokenUpdateTally(ctx context.Context, id stri
 }
 
 func (ms *MultiAllStorage) StoreUserAuthenticate(r *mdm.Request, msg *mdm.UserAuthenticate) error {
-	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreUserAuthenticate(r, msg)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) Disable(r *mdm.Request) error {
-	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.Disable(r)
 	})
 	return err

--- a/storage/allmulti/bstoken.go
+++ b/storage/allmulti/bstoken.go
@@ -6,14 +6,14 @@ import (
 )
 
 func (ms *MultiAllStorage) StoreBootstrapToken(r *mdm.Request, msg *mdm.SetBootstrapToken) error {
-	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreBootstrapToken(r, msg)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) RetrieveBootstrapToken(r *mdm.Request, msg *mdm.GetBootstrapToken) (*mdm.BootstrapToken, error) {
-	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return s.RetrieveBootstrapToken(r, msg)
 	})
 	return val.(*mdm.BootstrapToken), err

--- a/storage/allmulti/certauth.go
+++ b/storage/allmulti/certauth.go
@@ -8,28 +8,28 @@ import (
 )
 
 func (ms *MultiAllStorage) HasCertHash(r *mdm.Request, hash string) (bool, error) {
-	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return s.HasCertHash(r, hash)
 	})
 	return val.(bool), err
 }
 
 func (ms *MultiAllStorage) EnrollmentHasCertHash(r *mdm.Request, hash string) (bool, error) {
-	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return s.EnrollmentHasCertHash(r, hash)
 	})
 	return val.(bool), err
 }
 
 func (ms *MultiAllStorage) IsCertHashAssociated(r *mdm.Request, hash string) (bool, error) {
-	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return s.IsCertHashAssociated(r, hash)
 	})
 	return val.(bool), err
 }
 
 func (ms *MultiAllStorage) AssociateCertHash(r *mdm.Request, hash string) error {
-	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.AssociateCertHash(r, hash)
 	})
 	return err

--- a/storage/allmulti/queue.go
+++ b/storage/allmulti/queue.go
@@ -8,21 +8,21 @@ import (
 )
 
 func (ms *MultiAllStorage) StoreCommandReport(r *mdm.Request, report *mdm.CommandResults) error {
-	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.StoreCommandReport(r, report)
 	})
 	return err
 }
 
 func (ms *MultiAllStorage) RetrieveNextCommand(r *mdm.Request, skipNotNow bool) (*mdm.Command, error) {
-	val, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	val, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return s.RetrieveNextCommand(r, skipNotNow)
 	})
 	return val.(*mdm.Command), err
 }
 
 func (ms *MultiAllStorage) ClearQueue(r *mdm.Request) error {
-	_, err := ms.execStores(r.Context, func(s storage.AllStorage) (interface{}, error) {
+	_, err := ms.execStores(r.Context(), func(s storage.AllStorage) (interface{}, error) {
 		return nil, s.ClearQueue(r)
 	})
 	return err

--- a/storage/kv/bstoken.go
+++ b/storage/kv/bstoken.go
@@ -21,7 +21,7 @@ func (s *KV) StoreBootstrapToken(r *mdm.Request, msg *mdm.SetBootstrapToken) err
 		return storage.ErrDeviceChannelOnly
 	}
 	return s.devices.Set(
-		r.Context,
+		r.Context(),
 		join(r.ID, keyBootstrapToken),
 		msg.BootstrapToken.BootstrapToken,
 	)
@@ -36,7 +36,7 @@ func (s *KV) RetrieveBootstrapToken(r *mdm.Request, msg *mdm.GetBootstrapToken) 
 		return nil, storage.ErrDeviceChannelOnly
 	}
 	v, err := s.devices.Get(
-		r.Context,
+		r.Context(),
 		join(r.ID, keyBootstrapToken),
 	)
 	if errors.Is(err, kv.ErrKeyNotFound) {

--- a/storage/kv/certauth.go
+++ b/storage/kv/certauth.go
@@ -16,17 +16,17 @@ const (
 
 // HasCertHash checks if hash has ever been associated to any enrollment.
 func (s *KV) HasCertHash(r *mdm.Request, hash string) (bool, error) {
-	return s.certAuth.Has(r.Context, join(hash, keyHashCert))
+	return s.certAuth.Has(r.Context(), join(hash, keyHashCert))
 }
 
 // EnrollmentHasCertHash checks that r.ID has any hash associated.
 func (s *KV) EnrollmentHasCertHash(r *mdm.Request, _ string) (bool, error) {
-	return s.certAuth.Has(r.Context, join(r.ID, keyCertHash))
+	return s.certAuth.Has(r.Context(), join(r.ID, keyCertHash))
 }
 
 // IsCertHashAssociated checks that r.ID is associated with hash.
 func (s *KV) IsCertHashAssociated(r *mdm.Request, hash string) (bool, error) {
-	kvHash, err := s.certAuth.Get(r.Context, join(r.ID, keyCertHash))
+	kvHash, err := s.certAuth.Get(r.Context(), join(r.ID, keyCertHash))
 	if errors.Is(err, kv.ErrKeyNotFound) {
 		return false, nil
 	}
@@ -36,7 +36,7 @@ func (s *KV) IsCertHashAssociated(r *mdm.Request, hash string) (bool, error) {
 // AssociateCertHash associates r.ID with hash.
 // Here hash is a cryptographic hash of the request certificate.
 func (s *KV) AssociateCertHash(r *mdm.Request, hash string) error {
-	return kv.PerformCRUDBucketTxn(r.Context, s.certAuth, func(ctx context.Context, b kv.CRUDBucket) error {
+	return kv.PerformCRUDBucketTxn(r.Context(), s.certAuth, func(ctx context.Context, b kv.CRUDBucket) error {
 		return kv.SetMap(ctx, b, map[string][]byte{
 			join(r.ID, keyCertHash): []byte(hash),
 			join(hash, keyHashCert): []byte(r.ID),

--- a/storage/kv/kv.go
+++ b/storage/kv/kv.go
@@ -54,5 +54,5 @@ func (s *KV) updateLastSeen(r *mdm.Request, b kv.RWBucket) error {
 	if b == nil {
 		b = s.enrollments
 	}
-	return b.Set(r.Context, join(r.ID, keyLastSeenAt), timeFmt(time.Now()))
+	return b.Set(r.Context(), join(r.ID, keyLastSeenAt), timeFmt(time.Now()))
 }

--- a/storage/mysql/bstoken.go
+++ b/storage/mysql/bstoken.go
@@ -8,7 +8,7 @@ import (
 
 func (s *MySQLStorage) StoreBootstrapToken(r *mdm.Request, msg *mdm.SetBootstrapToken) error {
 	_, err := s.db.ExecContext(
-		r.Context,
+		r.Context(),
 		`UPDATE devices SET bootstrap_token_b64 = ?, bootstrap_token_at = CURRENT_TIMESTAMP WHERE id = ? LIMIT 1;`,
 		nullEmptyString(msg.BootstrapToken.BootstrapToken.String()),
 		r.ID,
@@ -22,7 +22,7 @@ func (s *MySQLStorage) StoreBootstrapToken(r *mdm.Request, msg *mdm.SetBootstrap
 func (s *MySQLStorage) RetrieveBootstrapToken(r *mdm.Request, _ *mdm.GetBootstrapToken) (*mdm.BootstrapToken, error) {
 	var tokenB64 sql.NullString
 	err := s.db.QueryRowContext(
-		r.Context,
+		r.Context(),
 		`SELECT bootstrap_token_b64 FROM devices WHERE id = ?;`,
 		r.ID,
 	).Scan(&tokenB64)

--- a/storage/mysql/certauth.go
+++ b/storage/mysql/certauth.go
@@ -18,7 +18,7 @@ func (s *MySQLStorage) queryRowContextRowExists(ctx context.Context, query strin
 
 func (s *MySQLStorage) EnrollmentHasCertHash(r *mdm.Request, _ string) (bool, error) {
 	return s.queryRowContextRowExists(
-		r.Context,
+		r.Context(),
 		`SELECT COUNT(*) FROM cert_auth_associations WHERE id = ?;`,
 		r.ID,
 	)
@@ -26,7 +26,7 @@ func (s *MySQLStorage) EnrollmentHasCertHash(r *mdm.Request, _ string) (bool, er
 
 func (s *MySQLStorage) HasCertHash(r *mdm.Request, hash string) (bool, error) {
 	return s.queryRowContextRowExists(
-		r.Context,
+		r.Context(),
 		`SELECT COUNT(*) FROM cert_auth_associations WHERE sha256 = ?;`,
 		strings.ToLower(hash),
 	)
@@ -34,7 +34,7 @@ func (s *MySQLStorage) HasCertHash(r *mdm.Request, hash string) (bool, error) {
 
 func (s *MySQLStorage) IsCertHashAssociated(r *mdm.Request, hash string) (bool, error) {
 	return s.queryRowContextRowExists(
-		r.Context,
+		r.Context(),
 		`SELECT COUNT(*) FROM cert_auth_associations WHERE id = ? AND sha256 = ?;`,
 		r.ID, strings.ToLower(hash),
 	)
@@ -42,7 +42,7 @@ func (s *MySQLStorage) IsCertHashAssociated(r *mdm.Request, hash string) (bool, 
 
 func (s *MySQLStorage) AssociateCertHash(r *mdm.Request, hash string) error {
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO cert_auth_associations (id, sha256) VALUES (?, ?) AS new
 ON DUPLICATE KEY
 UPDATE sha256 = new.sha256;`,

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -100,7 +100,7 @@ func (s *MySQLStorage) StoreAuthenticate(r *mdm.Request, msg *mdm.Authenticate) 
 		pemCert = cryptoutil.PEMCertificate(r.Certificate.Raw)
 	}
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO devices
     (id, identity_cert, serial_number, authenticate, authenticate_at)
 VALUES
@@ -128,7 +128,7 @@ func (s *MySQLStorage) storeDeviceTokenUpdate(r *mdm.Request, msg *mdm.TokenUpda
 	}
 	query += ` WHERE id = ? LIMIT 1;`
 	args = append(args, r.ID)
-	_, err := s.db.ExecContext(r.Context, query, args...)
+	_, err := s.db.ExecContext(r.Context(), query, args...)
 	return err
 }
 
@@ -136,12 +136,12 @@ func (s *MySQLStorage) storeUserTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate
 	// there shouldn't be an Unlock Token on the user channel, but
 	// complain if there is to warn an admin
 	if len(msg.UnlockToken) > 0 {
-		ctxlog.Logger(r.Context, s.logger).Info(
+		ctxlog.Logger(r.Context(), s.logger).Info(
 			"msg", "Unlock Token on user channel not stored",
 		)
 	}
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO users
     (id, device_id, user_short_name, user_long_name, token_update, token_update_at)
 VALUES
@@ -181,7 +181,7 @@ func (s *MySQLStorage) StoreTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate) er
 		return err
 	}
 	_, err = s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO enrollments
 	(id, device_id, user_id, type, topic, push_magic, token_hex, last_seen_at, token_update_tally)
 VALUES
@@ -228,7 +228,7 @@ func (s *MySQLStorage) StoreUserAuthenticate(r *mdm.Request, msg *mdm.UserAuthen
 		colAtName = "user_authenticate_digest_at"
 	}
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO users
     (id, device_id, user_short_name, user_long_name, `+colName+`, `+colAtName+`)
 VALUES
@@ -258,7 +258,7 @@ func (s *MySQLStorage) Disable(r *mdm.Request) error {
 		return errors.New("can only disable a device channel")
 	}
 	_, err := s.db.ExecContext(
-		r.Context,
+		r.Context(),
 		`UPDATE enrollments SET enabled = 0, token_update_tally = 0, last_seen_at = CURRENT_TIMESTAMP WHERE device_id = ? AND enabled = 1;`,
 		r.ID,
 	)
@@ -267,7 +267,7 @@ func (s *MySQLStorage) Disable(r *mdm.Request) error {
 
 func (s *MySQLStorage) updateLastSeen(r *mdm.Request) (err error) {
 	_, err = s.db.ExecContext(
-		r.Context,
+		r.Context(),
 		`UPDATE enrollments SET last_seen_at = CURRENT_TIMESTAMP WHERE id = ?`,
 		r.ID,
 	)

--- a/storage/mysql/queue.go
+++ b/storage/mysql/queue.go
@@ -99,11 +99,11 @@ WHERE
 }
 
 func (s *MySQLStorage) deleteCommandTx(r *mdm.Request, result *mdm.CommandResults) error {
-	tx, err := s.db.BeginTx(r.Context, nil)
+	tx, err := s.db.BeginTx(r.Context(), nil)
 	if err != nil {
 		return err
 	}
-	if err = s.deleteCommand(r.Context, tx, r.ID, result.CommandUUID); err != nil {
+	if err = s.deleteCommand(r.Context(), tx, r.ID, result.CommandUUID); err != nil {
 		if rbErr := tx.Rollback(); rbErr != nil {
 			return fmt.Errorf("rollback error: %w; while trying to handle error: %v", rbErr, err)
 		}
@@ -131,7 +131,7 @@ func (s *MySQLStorage) StoreCommandReport(r *mdm.Request, result *mdm.CommandRes
 		notNowBumpTallySQL = `, command_results.not_now_tally = command_results.not_now_tally + 1`
 	}
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO command_results
     (id, command_uuid, status, result, not_now_at, not_now_tally)
 VALUES
@@ -151,7 +151,7 @@ UPDATE
 func (s *MySQLStorage) RetrieveNextCommand(r *mdm.Request, skipNotNow bool) (*mdm.Command, error) {
 	command := new(mdm.Command)
 	err := s.db.QueryRowContext(
-		r.Context, `
+		r.Context(), `
 SELECT c.command_uuid, c.request_type, c.command
 FROM enrollment_queue AS q
     INNER JOIN commands AS c
@@ -185,7 +185,7 @@ func (s *MySQLStorage) ClearQueue(r *mdm.Request) error {
 	// device ID, but all user-channel enrollments with a 'parent' ID of
 	// this device, too.
 	_, err := s.db.ExecContext(
-		r.Context,
+		r.Context(),
 		`
 UPDATE
     enrollment_queue AS q

--- a/storage/pgsql/bstoken.go
+++ b/storage/pgsql/bstoken.go
@@ -8,7 +8,7 @@ import (
 
 func (s *PgSQLStorage) StoreBootstrapToken(r *mdm.Request, msg *mdm.SetBootstrapToken) error {
 	_, err := s.db.ExecContext(
-		r.Context,
+		r.Context(),
 		`UPDATE devices SET bootstrap_token_b64 = $1, bootstrap_token_at = CURRENT_TIMESTAMP WHERE id = $2;`,
 		nullEmptyString(msg.BootstrapToken.BootstrapToken.String()),
 		r.ID,
@@ -22,7 +22,7 @@ func (s *PgSQLStorage) StoreBootstrapToken(r *mdm.Request, msg *mdm.SetBootstrap
 func (s *PgSQLStorage) RetrieveBootstrapToken(r *mdm.Request, _ *mdm.GetBootstrapToken) (*mdm.BootstrapToken, error) {
 	var tokenB64 sql.NullString
 	err := s.db.QueryRowContext(
-		r.Context,
+		r.Context(),
 		`SELECT bootstrap_token_b64 FROM devices WHERE id = $1;`,
 		r.ID,
 	).Scan(&tokenB64)

--- a/storage/pgsql/certauth.go
+++ b/storage/pgsql/certauth.go
@@ -18,7 +18,7 @@ func (s *PgSQLStorage) queryRowContextRowExists(ctx context.Context, query strin
 
 func (s *PgSQLStorage) EnrollmentHasCertHash(r *mdm.Request, _ string) (bool, error) {
 	return s.queryRowContextRowExists(
-		r.Context,
+		r.Context(),
 		`SELECT COUNT(*) FROM cert_auth_associations WHERE id = $1;`,
 		r.ID,
 	)
@@ -26,7 +26,7 @@ func (s *PgSQLStorage) EnrollmentHasCertHash(r *mdm.Request, _ string) (bool, er
 
 func (s *PgSQLStorage) HasCertHash(r *mdm.Request, hash string) (bool, error) {
 	return s.queryRowContextRowExists(
-		r.Context,
+		r.Context(),
 		`SELECT COUNT(*) FROM cert_auth_associations WHERE sha256 = $1;`,
 		strings.ToLower(hash),
 	)
@@ -34,7 +34,7 @@ func (s *PgSQLStorage) HasCertHash(r *mdm.Request, hash string) (bool, error) {
 
 func (s *PgSQLStorage) IsCertHashAssociated(r *mdm.Request, hash string) (bool, error) {
 	return s.queryRowContextRowExists(
-		r.Context,
+		r.Context(),
 		`SELECT COUNT(*) FROM cert_auth_associations WHERE id = $1 AND sha256 = $2;`,
 		r.ID, strings.ToLower(hash),
 	)
@@ -43,7 +43,7 @@ func (s *PgSQLStorage) IsCertHashAssociated(r *mdm.Request, hash string) (bool, 
 // AssociateCertHash "DO NOTHING" on duplicated keys
 func (s *PgSQLStorage) AssociateCertHash(r *mdm.Request, hash string) error {
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO cert_auth_associations (id, sha256) 
 VALUES ($1, $2)
 ON CONFLICT ON CONSTRAINT cert_auth_associations_pkey DO UPDATE SET updated_at=now();`,

--- a/storage/pgsql/postgresql.go
+++ b/storage/pgsql/postgresql.go
@@ -100,7 +100,7 @@ func (s *PgSQLStorage) StoreAuthenticate(r *mdm.Request, msg *mdm.Authenticate) 
 		pemCert = cryptoutil.PEMCertificate(r.Certificate.Raw)
 	}
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO devices
     (id, identity_cert, serial_number, authenticate, authenticate_at)
 VALUES
@@ -129,7 +129,7 @@ func (s *PgSQLStorage) storeDeviceTokenUpdate(r *mdm.Request, msg *mdm.TokenUpda
 		where = ` WHERE id = $3;`
 	}
 	args = append(args, r.ID)
-	_, err := s.db.ExecContext(r.Context, query+where, args...)
+	_, err := s.db.ExecContext(r.Context(), query+where, args...)
 	return err
 }
 
@@ -137,12 +137,12 @@ func (s *PgSQLStorage) storeUserTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate
 	// there shouldn't be an Unlock Token on the user channel, but
 	// complain if there is to warn an admin
 	if len(msg.UnlockToken) > 0 {
-		ctxlog.Logger(r.Context, s.logger).Info(
+		ctxlog.Logger(r.Context(), s.logger).Info(
 			"msg", "Unlock Token on user channel not stored",
 		)
 	}
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO users
     (id, device_id, user_short_name, user_long_name, token_update, token_update_at)
 VALUES
@@ -182,7 +182,7 @@ func (s *PgSQLStorage) StoreTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate) er
 		return err
 	}
 	_, err = s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO enrollments
 	(id, device_id, user_id, type, topic, push_magic, token_hex, last_seen_at, token_update_tally)
 VALUES
@@ -229,7 +229,7 @@ func (s *PgSQLStorage) StoreUserAuthenticate(r *mdm.Request, msg *mdm.UserAuthen
 		colAtName = "user_authenticate_digest_at"
 	}
 	_, err := s.db.ExecContext(
-		r.Context, `
+		r.Context(), `
 INSERT INTO users
     (id, device_id, user_short_name, user_long_name, `+colName+`, `+colAtName+`)
 VALUES
@@ -259,7 +259,7 @@ func (s *PgSQLStorage) Disable(r *mdm.Request) error {
 		return errors.New("can only disable a device channel")
 	}
 	_, err := s.db.ExecContext(
-		r.Context,
+		r.Context(),
 		`UPDATE enrollments SET enabled = FALSE, token_update_tally = 0, last_seen_at = CURRENT_TIMESTAMP WHERE device_id = $1 AND enabled = TRUE;`,
 		r.ID,
 	)
@@ -268,7 +268,7 @@ func (s *PgSQLStorage) Disable(r *mdm.Request) error {
 
 func (s *PgSQLStorage) updateLastSeen(r *mdm.Request) (err error) {
 	_, err = s.db.ExecContext(
-		r.Context,
+		r.Context(),
 		`UPDATE enrollments SET last_seen_at = CURRENT_TIMESTAMP WHERE id = $1`,
 		r.ID,
 	)

--- a/test/enrollment/enrollment.go
+++ b/test/enrollment/enrollment.go
@@ -273,11 +273,9 @@ func (e *Enrollment) EnrollID() *mdm.EnrollID {
 }
 
 func (e *Enrollment) NewMDMRequest(ctx context.Context) *mdm.Request {
-	return &mdm.Request{
-		Context:     ctx,
-		EnrollID:    e.EnrollID(),
-		Certificate: e.cert,
-	}
+	r := mdm.NewRequestWithContext(ctx, e.cert)
+	r.EnrollID = e.EnrollID()
+	return r
 }
 
 // GetPush returns the enrollment push info data.


### PR DESCRIPTION
In line with the stdlib `http` package, make the direct `context.Context` in the MDM request immutable. This forces users to retrieve it via an accessor method (`Context()`) and requires cloning the MDM request object to change the context, leaving the previous request object context untouched. This is all in service of more predictable and safer code.