### PR TITLE
activation unlock

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,6 +2,8 @@ openapi: 3.0.0
 info:
   version: 0.1.0
   title: NanoMDM API
+servers:
+  - url: http://[::1]:9000/
 paths:
   /v1/pushcert:
     put:
@@ -111,6 +113,73 @@ paths:
           schema:
             type: string
             example: '1'
+  /v1/escrowkeyunlock:
+    post:
+      description: "Perform an Escrow Key Unlock against Apple's API. Uses the APNs certificate of the provided topic for mTLS authentication. Note that despite all parameters being in the HTTP body (form) this endpoint moves the appropriate parameters to the URL query parameters per Apple's documentation. The response body, status, and headers are handed straight through from the Apple endpoint."
+      externalDocs:
+        description: Creating and Using Bypass Codes
+        url: https://developer.apple.com/documentation/devicemanagement/creating-and-using-bypass-codes
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - topic
+                - serial
+                - productType
+                - escrowKey
+                - orgName
+                - guid
+              properties:
+                topic:
+                  type: string
+                  description: APNs Push topic. The certificate keypair that matches this topic is used for mTLS authentication to the Apple Escrow Key Unlock endpoint.
+                  example: "com.apple.mgmt.External.f3abfeac-1f27-4c8e-8a63-dd17555d35d9"
+                serial:
+                  description: The deviceʼs serial number (required).
+                  type: string
+                  example: "C8TJ500QF1MN"
+                imei:
+                  description: The device’s IMEI (omit for non-cellular devices).
+                  type: string
+                imei2:
+                  description: The device’s secondary IMEI (omit for non-cellular and single-SIM devices).
+                  type: string
+                meid:
+                  description: The device’s MEID (omit for non-cellular devices).
+                  type: string
+                productType:
+                  description: "Example: iPad4,1 (required)."
+                  type: string
+                  example: "iPad4,1"
+                escrowKey:
+                  description: Dash-separated "human readable" form of the Activation Lock Bypass Code.
+                  type: string
+                  minLength: 31
+                  example: "3UM43-PUYVY-QYD1-UVCC-HEHJ-FKA4"
+                orgName:
+                  description: "The client-supplied value for auditing purposes: a string that identifies the name of the organization."
+                  type: string
+                  example: "Acme Inc"
+                guid:
+                  description: "The client-supplied value for auditing purposes: a string that identifies the user requesting the removal (such as email, LDAP ID, or name)."
+                  type: string
+                  example: "123456"
+      responses:
+        '200':
+          description: Success.
+        '400':
+          description: "Failure: bad request; likely cause is a malformed request query or body."
+        '404':
+          description: "Failure: device is not found, or escrowKey is invalid."
+        '500':
+          description: "Unexpected server error; try again later."
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
   /version:
     get:
       description: Returns the running NanoMDM version

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -363,6 +363,40 @@ The migration endpoint (as talked about above under the `-migration` switch) is 
 
 Returns a JSON response with the version of the running NanoMDM server.
 
+### Escrow Key Unlock
+
+* Endpoint: `POST /v1/escrowkeyunlock`
+
+The Escrow Key Unlock endpoint is a thin wrapper around Apple's `escrowKeyUnlock` endpoint. This allows for Activation *Un*locking devices provided you have details about the device from MDM and the appropriate Acitvation Lock Bypass Code. All parameters are provided in the the body as a standard form (`application/x-www-form-urlencoded`). At minimium you need to provide:
+
+- `topic`
+- `serial`
+- `productType`
+- `escrowKey`
+- `orgName`
+- `guid`
+
+For devices where it is appropriate you also need to provide:
+
+- `imei`
+- `imei2`
+- `meid`
+
+For example to clear Activation Lock on a Mac with serial number `C8TJ500QF1MN` one might perform this:
+
+```bash
+curl \
+	-v \
+	-u nanomdm:nanomdm \
+	-d "topic=com.apple.mgmt.External.f3abfeac-1f27-4c8e-8a63-dd17555d35d9" \
+	-d "serial=C8TJ500QF1MN" \
+	-d "productType=MacBookPro17,1" \
+	-d "escrowKey=3UM43-PUYVY-QYD1-UVCC-HEHJ-FKA4" \
+	-d "orgName=Acme Inc" \
+	-d "guid=12346" \
+	'http://[::1]:9000/v1/escrowkeyunlock'
+```
+
 ### Authentication Proxy
 
 * Endpoint: `/authproxy/`

--- a/http/api/api.go
+++ b/http/api/api.go
@@ -300,3 +300,28 @@ func StorePushCertHandler(storage storage.PushCertStore, logger log.Logger) http
 		}
 	}
 }
+
+// logAndJSONError is a helper for both logging and outputting errors in JSON.
+func logAndJSONError(logger log.Logger, w http.ResponseWriter, msg string, inErr error, header int) {
+	logger.Info("msg", msg, "err", inErr)
+
+	if header < 1 {
+		header = http.StatusInternalServerError
+	}
+
+	w.Header().Set("Content-type", "application/json")
+	w.WriteHeader(header)
+
+	type jsonError struct {
+		Error string `json:"error"`
+	}
+
+	out := &jsonError{Error: inErr.Error()}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "\t")
+	err := enc.Encode(out)
+	if err != nil && logger != nil {
+		logger.Info("msg", "encoding json", "err", err)
+	}
+}

--- a/http/api/escrowkeyunlock.go
+++ b/http/api/escrowkeyunlock.go
@@ -25,6 +25,10 @@ func fillUnlockParams(v url.Values) *escrowkeyunlock.EscrowKeyUnlockParams {
 	}
 }
 
+// NewEscrowKeyUnlockHandler creates an Escrow Key Unlock (i.e. Activation Lock Bypass) handler.
+// The handler takes in all parameters in the HTTP post form and
+// splits them between the required form and URL query parameters for Apple.
+// APNs keypairs are read for store.
 // The default HTTP client will be used if client is nil.
 func NewEscrowKeyUnlockHandler(store storage.PushCertStore, client *http.Client, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/http/api/escrowkeyunlock.go
+++ b/http/api/escrowkeyunlock.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/micromdm/nanolib/log"
+	"github.com/micromdm/nanolib/log/ctxlog"
+	"github.com/micromdm/nanomdm/http/escrowkeyunlock"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+func fillUnlockParams(v url.Values) *escrowkeyunlock.EscrowKeyUnlockParams {
+	return &escrowkeyunlock.EscrowKeyUnlockParams{
+		Serial:      v.Get("serial"),
+		IMEI:        v.Get("imei"),
+		IMEI2:       v.Get("imei2"),
+		MEID:        v.Get("meid"),
+		ProductType: v.Get("productType"),
+		OrgName:     v.Get("orgName"),
+		GUID:        v.Get("guid"),
+		EscrowKey:   v.Get("escrowKey"),
+	}
+}
+
+// The default HTTP client will be used if client is nil.
+func NewEscrowKeyUnlockHandler(store storage.PushCertStore, client *http.Client, logger log.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
+		r.ParseForm()
+		values := r.PostForm
+		params := fillUnlockParams(values)
+
+		if !params.Valid() {
+			err := errors.New("invalid or missing parameters")
+			logAndJSONError(logger, w, "validating parameters", err, http.StatusBadRequest)
+			return
+		}
+
+		topic := values.Get("topic")
+		if topic == "" {
+			err := errors.New("empty topic")
+			logAndJSONError(logger, w, "validating parameters", err, http.StatusBadRequest)
+			return
+		}
+
+		resp, err := escrowkeyunlock.DoEscrowKeyUnlock(
+			r.Context(),
+			store,
+			topic,
+			nil,
+			params.QueryParams(),
+			params.FormParams(),
+		)
+		if err != nil {
+			logAndJSONError(logger, w, "escrow key unlock", err, 0)
+			return
+		}
+		defer resp.Body.Close()
+
+		// copy status
+		w.WriteHeader(resp.StatusCode)
+
+		// copy headers
+		for k, values := range resp.Header {
+			for _, v := range values {
+				w.Header().Add(k, v)
+			}
+		}
+
+		logger.Debug(
+			"msg", "escrow key unlock",
+			"serial", params.Serial,
+			"http_status", resp.StatusCode,
+		)
+
+		// copy body
+		_, err = io.Copy(w, resp.Body)
+		if err != nil {
+			logger.Info("msg", "copying body", "err", err)
+		}
+	}
+}

--- a/http/api/v1.go
+++ b/http/api/v1.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	APIEndpointPushCert = "/pushcert"
-	APIEndpointPush     = "/push/"    // note trailing slash
-	APIEndpointEnqueue  = "/enqueue/" // note trailing slash
+	APIEndpointPushCert        = "/pushcert"
+	APIEndpointPush            = "/push/"    // note trailing slash
+	APIEndpointEnqueue         = "/enqueue/" // note trailing slash
+	APIEndpointEscrowKeyUnlock = "/escrowkeyunlock"
 )
 
 // Mux can register HTTP handlers.
@@ -76,5 +77,11 @@ func HandleAPIv1(prefix string, mux Mux, logger log.Logger, store APIStorage, pu
 				logger.With("handler", handlerName(APIEndpointEnqueue)),
 			),
 		),
+	)
+
+	// register API handler for escrow key unlock
+	mux.Handle(
+		prefix+APIEndpointEscrowKeyUnlock,
+		NewEscrowKeyUnlockHandler(store, nil, logger.With("handler", handlerName(APIEndpointEscrowKeyUnlock))),
 	)
 }

--- a/http/client.go
+++ b/http/client.go
@@ -8,9 +8,9 @@ import (
 
 var ErrNilCert = errors.New("nil cert")
 
-// ClientWithCert injects cert for mTLS usage into client.
+// ClientWithCert injects cert for mTLS into a copy of client.
 // Transports and TLS configs are created (if nil) or cloned as needed.
-// A nil client will use a clone of the default HTTP client.
+// If client is nil the default HTTP client will be used.
 func ClientWithCert(client *http.Client, cert *tls.Certificate) (*http.Client, error) {
 	if cert == nil {
 		return client, ErrNilCert

--- a/http/client.go
+++ b/http/client.go
@@ -1,0 +1,39 @@
+package http
+
+import (
+	"crypto/tls"
+	"errors"
+	"net/http"
+)
+
+var ErrNilCert = errors.New("nil cert")
+
+// ClientWithCert injects cert for mTLS usage into client.
+// Transports and TLS configs are created (if nil) or cloned as needed.
+// A nil client will use a clone of the default HTTP client.
+func ClientWithCert(client *http.Client, cert *tls.Certificate) (*http.Client, error) {
+	if cert == nil {
+		return client, ErrNilCert
+	}
+
+	if client == nil {
+		client = http.DefaultClient
+	}
+	clientCopy := *client
+	client = &clientCopy
+
+	if client.Transport == nil {
+		client.Transport = http.DefaultTransport
+	}
+	transport := client.Transport.(*http.Transport).Clone()
+	client.Transport = transport
+
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	} else {
+		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	}
+	transport.TLSClientConfig.Certificates = []tls.Certificate{*cert}
+
+	return client, nil
+}

--- a/http/escrowkeyunlock/activationlock.go
+++ b/http/escrowkeyunlock/activationlock.go
@@ -1,0 +1,52 @@
+package escrowkeyunlock
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	nanohttp "github.com/micromdm/nanomdm/http"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const EscrowKeyUnlockURL = "https://deviceservices-external.apple.com/deviceservicesworkers/escrowKeyUnlock"
+
+// DoDisableActivationLock sends an "escrow key unlock" request to Apple.
+// Mutual TLS authentication against the endpoint uses the APNs TLS keypair identified by topic in store.
+// Required parameters must be supplied in queryParams and formParams: see [EscrowKeyUnlockParams].
+// Caller is responsible for reading and closing HTTP response.
+// See https://developer.apple.com/documentation/devicemanagement/creating-and-using-bypass-codes
+func DoDisableActivationLock(ctx context.Context, store storage.PushCertStore, topic string, client *http.Client, queryParams, formParams url.Values) (*http.Response, error) {
+	if store == nil {
+		panic("nil store")
+	}
+	if queryParams == nil || formParams == nil {
+		panic("nil params")
+	}
+
+	cert, _, err := store.RetrievePushCert(ctx, topic)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve push cert for topic: %s: %w", topic, err)
+	}
+
+	client, err = nanohttp.ClientWithCert(client, cert)
+	if err != nil {
+		return nil, fmt.Errorf("adapting client for mTLS: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		EscrowKeyUnlockURL+"?"+queryParams.Encode(),
+		strings.NewReader(formParams.Encode()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return client.Do(req)
+}

--- a/http/escrowkeyunlock/activationlock.go
+++ b/http/escrowkeyunlock/activationlock.go
@@ -13,12 +13,12 @@ import (
 
 const EscrowKeyUnlockURL = "https://deviceservices-external.apple.com/deviceservicesworkers/escrowKeyUnlock"
 
-// DoDisableActivationLock sends an "escrow key unlock" request to Apple.
+// DoEscrowKeyUnlock sends an "escrow key unlock" request to Apple.
 // Mutual TLS authentication against the endpoint uses the APNs TLS keypair identified by topic in store.
 // Required parameters must be supplied in queryParams and formParams: see [EscrowKeyUnlockParams].
 // Caller is responsible for reading and closing HTTP response.
 // See https://developer.apple.com/documentation/devicemanagement/creating-and-using-bypass-codes
-func DoDisableActivationLock(ctx context.Context, store storage.PushCertStore, topic string, client *http.Client, queryParams, formParams url.Values) (*http.Response, error) {
+func DoEscrowKeyUnlock(ctx context.Context, store storage.PushCertStore, topic string, client *http.Client, queryParams, formParams url.Values) (*http.Response, error) {
 	if store == nil {
 		panic("nil store")
 	}

--- a/http/escrowkeyunlock/params.go
+++ b/http/escrowkeyunlock/params.go
@@ -1,0 +1,78 @@
+package escrowkeyunlock
+
+import "net/url"
+
+type EscrowKeyUnlockParams struct {
+	// The deviceʼs serial number (required).
+	// Provided in URL request string as "serial".
+	Serial string
+
+	// The device’s IMEI (omit for non-cellular devices).
+	// Provided in URL request string as "imei".
+	IMEI string
+
+	// The device’s secondary IMEI (omit for non-cellular and
+	// single-SIM devices).
+	// Provided in URL request string as "imei2".
+	IMEI2 string
+
+	// The device’s MEID (omit for non-cellular devices).
+	// Provided in URL request string as "meid".
+	MEID string
+
+	// Example: iPad4,1 (required).
+	// Provided in URL request string as "productType".
+	ProductType string
+
+	// The client-supplied value for auditing purposes: a string that
+	// identifies the name of the organization.
+	// Provided in request form (body) as "orgName".
+	OrgName string
+
+	// The client-supplied value for auditing purposes: a string that
+	// identifies the user requesting the removal (such as email, LDAP
+	// ID, or name).
+	// Provided in request form (body) as "guid".
+	GUID string
+
+	// The device’s bypass code.
+	// Provided in request form (body) as "escrowKey".
+	EscrowKey string
+}
+
+// Valid tests e for validity and required non-empty fields.
+func (e *EscrowKeyUnlockParams) Valid() bool {
+	if e == nil {
+		return false
+	}
+	if e.Serial == "" || e.ProductType == "" || e.OrgName == "" || e.GUID == "" || e.EscrowKey == "" {
+		return false
+	}
+	return true
+}
+
+// QueryParams builds query parameters for the "escrow key unlock" endpoint.
+func (e *EscrowKeyUnlockParams) QueryParams() url.Values {
+	q := make(url.Values)
+	q.Set("serial", e.Serial)
+	q.Set("productType", e.ProductType)
+	if e.IMEI != "" {
+		q.Set("imei", e.IMEI)
+	}
+	if e.IMEI2 != "" {
+		q.Set("imei", e.IMEI2)
+	}
+	if e.MEID != "" {
+		q.Set("imei", e.MEID)
+	}
+	return q
+}
+
+// QueryParams builds form parameters for the "escrow key unlock" endpoint.
+func (e *EscrowKeyUnlockParams) FormParams() url.Values {
+	f := make(url.Values)
+	f.Set("orgName", e.OrgName)
+	f.Set("guid", e.GUID)
+	f.Set("escrowKey", e.EscrowKey)
+	return f
+}

--- a/http/escrowkeyunlock/params.go
+++ b/http/escrowkeyunlock/params.go
@@ -37,6 +37,7 @@ type EscrowKeyUnlockParams struct {
 
 	// The device’s bypass code.
 	// Provided in request form (body) as "escrowKey".
+	// Note: This escrow key is the dash-separated "human readable" form.
 	EscrowKey string
 }
 
@@ -60,10 +61,10 @@ func (e *EscrowKeyUnlockParams) QueryParams() url.Values {
 		q.Set("imei", e.IMEI)
 	}
 	if e.IMEI2 != "" {
-		q.Set("imei", e.IMEI2)
+		q.Set("imei2", e.IMEI2)
 	}
 	if e.MEID != "" {
-		q.Set("imei", e.MEID)
+		q.Set("meid", e.MEID)
 	}
 	return q
 }


### PR DESCRIPTION
Add ability to unlock a device which has been Activation Locked by using the Apple "escrowKeyUnlock" endpoint. This requires sending device details and an Activation Lock Bypass Code.

We expose a new HTTP POST endpoint, `/v1/escrowkeyunlock`, which takes in all parameters in the HTTP post form and splits them between the required form and URL query parameters before submitting to the Apple Escrow Key Unlock endpoint. It will authenticate with mTLS by using a specified APNs certificate topic.

More details provided in the included documentation in the [Operations Guide](https://github.com/micromdm/nanomdm/blob/main/docs/operations-guide.md) and [OpenAPI spec](https://github.com/micromdm/nanomdm/blob/main/docs/openapi.yaml) (once merged). See also [Creating and Using Bypass Codes](https://developer.apple.com/documentation/devicemanagement/creating-and-using-bypass-codes).