### PR TITLE
Initial draft of enrollments API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -169,6 +169,63 @@ paths:
           description: "Unexpected server error; try again later."
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+  /v1/enrollments/query:
+    post:
+      description: "Query MDM enrollments with filtering and pagination."
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnrollmentAPIRequest'
+            example:
+              enrollment_types: ['Device']
+              is_enabled: true
+              limit: 50
+      responses:
+        '200':
+          description: Success. Returns a list of enrollments matching the query.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnrollmentAPIResult'
+              example:
+                enrollments:
+                  - id: '299BD49-1A0C-422C-B285-2E4FF087C673'
+                    type: 'Device'
+                    device:
+                      serial_number: 'C8TJ500QF1MN'
+                    enabled: true
+                    token_update_tally: 12
+                    last_seen: '2025-01-15T14:30:00Z'
+                  - id: 'A1B2C3D4-5E6F-7G8H-9I0J-K1L2M3N4O5P6'
+                    type: 'Device'
+                    device:
+                      serial_number: 'DNPH3X2PQ1GY'
+                    enabled: true
+                    token_update_tally: 8
+                    last_seen: '2025-01-15T10:15:00Z'
+                next_token: '74CE1CA9-8ADD-43CD-B59D-3AC0375EE25F'
+        '400':
+          description: "Failure: bad request; likely cause is a malformed request query or body."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnrollmentAPIResult'
+              example:
+                error: "invalid request: 'NonExistentType' is not a valid enrollment type"
+        '500':
+          description: "Unexpected server error; try again later."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnrollmentAPIResult'
+              example:
+                error: "database connection failed"
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
   /version:
     get:
       description: Returns the running NanoMDM version
@@ -276,3 +333,116 @@ components:
           format: date-time
           description: Expiration date of the uploaded APNs certificate.
           example: '2026-01-07T04:04:46Z'
+    EnrollmentAPIRequest:
+      type: object
+      description: |
+        Query for MDM enrollments. All query parameters are optional.
+        If multiple parameters are provided, they are combined with logical AND.
+        e.g. if both enrollment_types and serials are provided, only enrollments matching both criteria are returned.
+      properties:
+        enrollment_types:
+          type: array
+          items:
+            type: string
+            enum: ['Device', 'User', 'User Enrollment (Device)', 'User Enrollment', 'Shared iPad']
+          description: Filters enrollments by their enrollment types.
+          example: ['Device', 'User Enrollment (Device)']
+        ids:
+          type: array
+          items:
+            type: string
+          description: Returns only enrollments matching the given enrollment IDs.
+          example: ['299BD49-1A0C-422C-B285-2E4FF087C673']
+        serials:
+          type: array
+          items:
+            type: string
+          description: Returns only enrollments matching the given serial numbers.
+          example: ['C8TJ500QF1MN']
+        is_enabled:
+          type: boolean
+          description: Filters enrollments by their enabled/disabled status. If omitted, both enabled and disabled enrollments are returned.
+          example: true
+        limit:
+          type: integer
+          description: Maximum number of enrollments to return in the response. If zero or omitted, all matching enrollments are returned.
+          example: 100
+        next_token:
+          type: string
+          description: Cursor for pagination. The first request should leave this empty. Subsequent requests should set this to the next_token value from the previous response.
+          example: '74CE1CA9-8ADD-43CD-B59D-3AC0375EE25F'
+    EnrollmentAPIResult:
+      type: object
+      description: Response containing a list of enrollments and pagination information.
+      properties:
+        enrollments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Enrollment'
+          description: List of enrollments matching the query.
+        next_token:
+          type: string
+          description: Cursor for pagination. If non-empty, more results may be fetched by setting this value in the next_token field of a subsequent request. Clients should not depend on a particular format of this token.
+          example: '74CE1CA9-8ADD-43CD-B59D-3AC0375EE25F'
+        error:
+          type: string
+          description: Error message if there was an error processing the request.
+    Enrollment:
+      type: object
+      description: Represents an MDM enrollment (device or user channel).
+      properties:
+        id:
+          type: string
+          description: The NanoMDM enrollment ID
+          example: '299BD49-1A0C-422C-B285-2E4FF087C673'
+        type:
+          type: string
+          enum: ['Device', 'User', 'User Enrollment (Device)', 'User Enrollment', 'Shared iPad']
+          description: Type of the enrollment. This value may be empty if the server has not receieved a TokenUpdate from this enrollment yet.
+          example: 'Device'
+        device:
+          $ref: '#/components/schemas/DeviceEnrollment'
+          description: Device information (present for device channel enrollments).
+        user:
+          $ref: '#/components/schemas/UserEnrollment'
+          description: User information (present for user channel enrollments).
+        enabled:
+          type: boolean
+          description: Indicates if the enrollment is active.
+          example: true
+        token_update_tally:
+          type: integer
+          description: Number of TokenUpdate messages received for this enrollment.
+          example: 5
+        last_seen:
+          type: string
+          format: date-time
+          description: Time of the last request from this enrollment.
+          example: '2025-01-15T14:30:00Z'
+      required:
+        - id
+        - enabled
+        - token_update_tally
+        - last_seen
+    DeviceEnrollment:
+      type: object
+      description: Device-specific enrollment information.
+      properties:
+        serial_number:
+          type: string
+          description: Device serial number.
+          example: 'C8TJ500QF1MN'
+      required:
+        - serial_number
+    UserEnrollment:
+      type: object
+      description: User-specific enrollment information.
+      properties:
+        user_short_name:
+          type: string
+          description: For macOS, this value is the short name of the user. For Shared iPad, this value is the Managed Apple Account identifier of the user on Shared iPad.
+          example: 'jane_smith'
+        user_long_name:
+          type: string
+          description: Full name of the user.
+          example: 'Jane Smith'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -177,11 +177,12 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Maximum number of enrollments to return in the response. If zero or omitted, all matching enrollments are returned.
+          description: Maximum number of enrollments to return in the response.
           required: false
           schema:
             type: integer
-            example: 50
+            example: 20
+            default: 100
         - name: offset
           in: query
           description: Offset for offset-based pagination. Use offset = 0 for the first request. Mutually exclusive with cursor-based pagination.
@@ -191,7 +192,7 @@ paths:
             example: 0
         - name: cursor
           in: query
-          description: Cursor for cursor-based pagination. The first request should leave this empty. Subsequent requests should set this to the next_token value from the previous response. Mutually exclusive with offset-based pagination.
+          description: Cursor for cursor-based pagination. The first request should leave this empty. Subsequent requests should set this to the next_cursor value from the previous response. Mutually exclusive with offset-based pagination.
           required: false
           schema:
             type: string
@@ -231,7 +232,7 @@ paths:
                     enabled: true
                     token_update_tally: 8
                     last_seen: '2025-01-15T10:15:00Z'
-                next_token: '74CE1CA9-8ADD-43CD-B59D-3AC0375EE25F'
+                next_cursor: '74CE1CA9-8ADD-43CD-B59D-3AC0375EE25F'
         '400':
           description: "Failure: bad request; likely cause is a malformed request query or body."
           content:
@@ -419,9 +420,9 @@ components:
           items:
             $ref: '#/components/schemas/Enrollment'
           description: List of enrollments matching the query.
-        next_token:
+        next_cursor:
           type: string
-          description: Cursor for pagination. If non-empty, more results may be fetched by setting this value in the next_token field of a subsequent request. Clients should not depend on a particular format of this token.
+          description: For storage backends that support cursor-based pagination this will contain the next cursor value.
           example: '74CE1CA9-8ADD-43CD-B59D-3AC0375EE25F'
         error:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -171,26 +171,50 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
   /v1/enrollments/query:
     post:
-      description: "Query MDM enrollments with filtering and pagination."
+      description: "Query MDM enrollments with filtering and pagination. Supports both offset-based and cursor-based pagination via query parameters."
       security:
         - basicAuth: []
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of enrollments to return in the response. If zero or omitted, all matching enrollments are returned.
+          required: false
+          schema:
+            type: integer
+            example: 50
+        - name: offset
+          in: query
+          description: Offset for offset-based pagination. Use offset = 0 for the first request. Mutually exclusive with cursor-based pagination.
+          required: false
+          schema:
+            type: integer
+            example: 0
+        - name: cursor
+          in: query
+          description: Cursor for cursor-based pagination. The first request should leave this empty. Subsequent requests should set this to the next_token value from the previous response. Mutually exclusive with offset-based pagination.
+          required: false
+          schema:
+            type: string
+            example: '74CE1CA9-8ADD-43CD-B59D-3AC0375EE25F'
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EnrollmentAPIRequest'
+              $ref: '#/components/schemas/EnrollmentsQuery'
             example:
-              enrollment_types: ['Device']
-              is_enabled: true
-              limit: 50
+              filter:
+                types: ['Device']
+                enabled: true
+              options:
+                include_device_cert: false
       responses:
         '200':
           description: Success. Returns a list of enrollments matching the query.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnrollmentAPIResult'
+                $ref: '#/components/schemas/EnrollmentsQueryResult'
               example:
                 enrollments:
                   - id: '299BD49-1A0C-422C-B285-2E4FF087C673'
@@ -213,7 +237,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnrollmentAPIResult'
+                $ref: '#/components/schemas/EnrollmentsQueryResult'
               example:
                 error: "invalid request: 'NonExistentType' is not a valid enrollment type"
         '500':
@@ -221,7 +245,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EnrollmentAPIResult'
+                $ref: '#/components/schemas/EnrollmentsQueryResult'
               example:
                 error: "database connection failed"
         '401':
@@ -333,20 +357,21 @@ components:
           format: date-time
           description: Expiration date of the uploaded APNs certificate.
           example: '2026-01-07T04:04:46Z'
-    EnrollmentAPIRequest:
+    EnrollmentsQuery:
+      type: object
+      description: Query for MDM enrollments. All fields are optional.
+      properties:
+        filter:
+          $ref: '#/components/schemas/EnrollmentsQueryFilter'
+        options:
+          $ref: '#/components/schemas/EnrollmentQueryOptions'
+    EnrollmentsQueryFilter:
       type: object
       description: |
-        Query for MDM enrollments. All query parameters are optional.
+        Filter for enrollments. All query parameters are optional.
         If multiple parameters are provided, they are combined with logical AND.
-        e.g. if both enrollment_types and serials are provided, only enrollments matching both criteria are returned.
+        e.g. if both types and serials are provided, only enrollments matching both criteria are returned.
       properties:
-        enrollment_types:
-          type: array
-          items:
-            type: string
-            enum: ['Device', 'User', 'User Enrollment (Device)', 'User Enrollment', 'Shared iPad']
-          description: Filters enrollments by their enrollment types.
-          example: ['Device', 'User Enrollment (Device)']
         ids:
           type: array
           items:
@@ -359,19 +384,33 @@ components:
             type: string
           description: Returns only enrollments matching the given serial numbers.
           example: ['C8TJ500QF1MN']
-        is_enabled:
+        user_short_names:
+          type: array
+          items:
+            type: string
+          description: Returns only enrollments matching the given user short names.
+          example: ['jane_smith', 'john_doe']
+        types:
+          type: array
+          items:
+            type: string
+            enum: ['Device', 'User', 'User Enrollment (Device)', 'User Enrollment', 'Shared iPad']
+          description: Filters enrollments by their enrollment types.
+          example: ['Device', 'User Enrollment (Device)']
+        enabled:
           type: boolean
           description: Filters enrollments by their enabled/disabled status. If omitted, both enabled and disabled enrollments are returned.
           example: true
-        limit:
-          type: integer
-          description: Maximum number of enrollments to return in the response. If zero or omitted, all matching enrollments are returned.
-          example: 100
-        next_token:
-          type: string
-          description: Cursor for pagination. The first request should leave this empty. Subsequent requests should set this to the next_token value from the previous response.
-          example: '74CE1CA9-8ADD-43CD-B59D-3AC0375EE25F'
-    EnrollmentAPIResult:
+    EnrollmentQueryOptions:
+      type: object
+      description: Options for enrollment query results.
+      properties:
+        include_device_cert:
+          type: boolean
+          description: By default, the Device Identity certificate is not included in the response. Set to true to include it.
+          default: false
+          example: false
+    EnrollmentsQueryResult:
       type: object
       description: Response containing a list of enrollments and pagination information.
       properties:

--- a/storage/enrollment.go
+++ b/storage/enrollment.go
@@ -1,0 +1,77 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/micromdm/nanomdm/mdm"
+)
+
+// EnrollmentAPIRequest represents a query for MDM enrollments. All query parameters are optional.
+// If multiple parameters are provided, they are combined with logical AND.
+// e.g. if both EnrollmentTypes and Serials are provided, only enrollments matching
+// both criteria are returned.
+type EnrollmentAPIRequest struct {
+	// EnrollmentTypes, if non-empty, filters enrollments by their enrollment types.
+	EnrollmentTypes []mdm.EnrollType `json:"enrollment_types,omitempty"`
+	// IDs, if non-empty, returns only enrollments matching the given enrollment IDs.
+	IDs []string `json:"ids,omitempty"`
+	// Serials, if non-empty, returns only enrollments matching the given serial numbers.
+	Serials []string `json:"serials,omitempty"`
+	// IsEnabled filters enrollments by their enabled/disabled status.
+	// If nil, both enabled and disabled enrollments are returned.
+	IsEnabled *bool `json:"is_enabled,omitempty"`
+	// Limit is the maximum number of enrollments to return in the response.
+	// If zero, all matching enrollments are returned.
+
+	Limit int `json:"limit,omitempty"`
+	// NextToken is a cursor for pagination. The first request should leave this empty.
+	// Subsequent requests should set this to the NextToken value from the previous response.
+	NextToken string `json:"next_token,omitempty"`
+}
+
+type DeviceEnrollment struct {
+	SerialNumber string `json:"serial_number"`
+}
+
+type UserEnrollment struct {
+	UserShortName string `json:"user_short_name,omitempty"`
+	UserLongName  string `json:"user_long_name,omitempty"`
+}
+
+type Enrollment struct {
+	// ID is the NanoMDM "enrollment ID":
+	// https://github.com/micromdm/nanomdm/blob/main/docs/operations-guide.md#enrollment-ids
+	ID string `json:"id"`
+
+	// Type is enrollment type, e.g. Device, User, etc.
+	Type mdm.EnrollType `json:"type,omitempty"`
+
+	// Device will be non-nil for device channel enrollments.
+	Device *DeviceEnrollment `json:"device,omitempty"`
+	// User will be non-nil for user channel enrollments.
+	User *UserEnrollment `json:"user,omitempty"`
+
+	// Enabled indicates if the enrollment is active.
+	Enabled bool `json:"enabled"`
+	// TokenUpdateTally is the number of TokenUpdate messages received for this enrollment.
+	TokenUpdateTally int `json:"token_update_tally"`
+	// LastSeen is the time of the last request from this enrollment.
+	LastSeen time.Time `json:"last_seen"`
+}
+
+type EnrollmentAPIResult struct {
+	Enrollments []*Enrollment `json:"enrollments"`
+	// NextToken is a cursor for pagination. If non-empty, more results may be fetched by
+	// setting this value in the NextToken field of a subsequent request.
+	NextToken string `json:"next_token,omitempty"`
+	// Error is present if there was an error processing the request.
+	Error string `json:"error,omitempty"`
+}
+
+type EnrollmentStore interface {
+	// QueryEnrollments retrieves MDM enrollments matching the given request.
+	// If no enrollments match the request, an empty EnrollmentAPIResult is returned with no error.
+	// Implementations should not set the Error field of EnrollmentAPIResult; errors should be returned via the error return value.
+	QueryEnrollments(ctx context.Context, req *EnrollmentAPIRequest) (*EnrollmentAPIResult, error)
+}

--- a/storage/enrollment.go
+++ b/storage/enrollment.go
@@ -11,23 +11,30 @@ import (
 // If multiple parameters are provided, they are combined with logical AND.
 // e.g. if both EnrollmentTypes and Serials are provided, only enrollments matching
 // both criteria are returned.
-type EnrollmentAPIRequest struct {
-	// EnrollmentTypes, if non-empty, filters enrollments by their enrollment types.
-	EnrollmentTypes []mdm.EnrollType `json:"enrollment_types,omitempty"`
-	// IDs, if non-empty, returns only enrollments matching the given enrollment IDs.
-	IDs []string `json:"ids,omitempty"`
-	// Serials, if non-empty, returns only enrollments matching the given serial numbers.
-	Serials []string `json:"serials,omitempty"`
-	// IsEnabled filters enrollments by their enabled/disabled status.
-	// If nil, both enabled and disabled enrollments are returned.
-	IsEnabled *bool `json:"is_enabled,omitempty"`
-	// Limit is the maximum number of enrollments to return in the response.
-	// If zero, all matching enrollments are returned.
+type EnrollmentQueryFilter struct {
+	IDs            []string
+	Serials        []string
+	UserShortNames []string
+	Types          []string
+	Enabled        *bool
+}
 
-	Limit int `json:"limit,omitempty"`
-	// NextToken is a cursor for pagination. The first request should leave this empty.
-	// Subsequent requests should set this to the NextToken value from the previous response.
-	NextToken string `json:"next_token,omitempty"`
+// Support both limit/offset, as well as cursor
+type Pagination struct {
+	Limit  int
+	Offset int
+	Cursor string
+}
+
+type EnrollmentQueryOptions struct {
+	// By default we do not include the Device Identity certificate in the response.
+	IncludeDeviceCert bool
+}
+
+type EnrollmentsQuery struct {
+	Filter     EnrollmentQueryFilter
+	Pagination Pagination
+	Options    EnrollmentQueryOptions
 }
 
 type DeviceEnrollment struct {

--- a/storage/enrollment.go
+++ b/storage/enrollment.go
@@ -12,11 +12,11 @@ import (
 // e.g. if both EnrollmentTypes and Serials are provided, only enrollments matching
 // both criteria are returned.
 type EnrollmentsQueryFilter struct {
-	IDs            []string
-	Serials        []string
-	UserShortNames []string
-	Types          []string
-	Enabled        *bool
+	IDs            []string `json:"ids,omitempty"`
+	Serials        []string `json:"serials,omitempty"`
+	UserShortNames []string `json:"user_short_names,omitempty"`
+	Types          []string `json:"types,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
 }
 
 // Pagination supports both limit/offset, as well as cursor.
@@ -30,14 +30,14 @@ type Pagination struct {
 
 type EnrollmentQueryOptions struct {
 	// By default we do not include the Device Identity certificate in the response.
-	IncludeDeviceCert bool
+	IncludeDeviceCert bool `json:"include_device_cert,omitempty"`
 }
 
 // EnrollmentsQuery represents a query for MDM enrollments.
 type EnrollmentsQuery struct {
-	Filter     EnrollmentsQueryFilter
-	Pagination Pagination
-	Options    EnrollmentQueryOptions
+	Filter     EnrollmentsQueryFilter `json:"filter,omitempty"`
+	Pagination Pagination             `json:"-"`
+	Options    EnrollmentQueryOptions `json:"options,omitempty"`
 }
 
 type DeviceEnrollment struct {

--- a/storage/enrollment.go
+++ b/storage/enrollment.go
@@ -19,31 +19,6 @@ type EnrollmentsQueryFilter struct {
 	Enabled        *bool    `json:"enabled,omitempty"`
 }
 
-// Pagination supports either offset or cursor based pagination methods for results.
-// Backend implementations may support one or both methods, and may use either by default.
-// Offset and Cursor cannot both be set.
-// Backend implementations may have a default Limit, so omitting it may be possible.
-// For offset based queries, Offset must be set.
-// For cursor based queries, Cursor must be set.
-type Pagination struct {
-	Limit *int `json:"limit,omitempty"`
-	Offset *int  `json:"offset,omitempty"`
-	Cursor *string `json:"cursor,omitempty"`
-}
-
-// ValidErr returns any validation errors with p.
-func (p Pagination) ValidError() error {
-  if p.Cursor != nil && p.Offset != nil {
-  	return errors.New("cursor and offset both exist")
-  }
-  return nil
-}
-
-// Valid returns true if p is valid.
-func (p Pagination) Valid() bool {
-	return p.ValidErr() == nil
-}
-
 type EnrollmentQueryOptions struct {
 	// By default we do not include the Device Identity certificate in the response.
 	IncludeDeviceCert bool `json:"include_device_cert,omitempty"`
@@ -101,12 +76,7 @@ type Enrollment struct {
 type EnrollmentsQueryResult struct {
 	Enrollments []*Enrollment `json:"enrollments"`
 
-	// NextCursor is the enxt cursor for pagination. 
-	// If present and using cursor based pagination more results may be fetched by
-	// setting this value in the Cursor field of a subsequent request in the Pagination.
-	NextCursor *string `json:"next_cursor,omitempty"`
-
-	// Error is present if there was an error processing the request.
+	PaginationNextCursor
 }
 
 type EnrollmentsStore interface {

--- a/storage/enrollment.go
+++ b/storage/enrollment.go
@@ -8,7 +8,7 @@ import (
 )
 
 // EnrollmentsQueryFilter is a filter for enrollments. All query parameters are optional.
-// If multiple parameters are provided, they are combined with logical AND.
+// If multiple parameters are provided, backend implementations should combine them with logical AND.
 // e.g. if both EnrollmentTypes and Serials are provided, only enrollments matching
 // both criteria are returned.
 type EnrollmentsQueryFilter struct {
@@ -19,32 +19,57 @@ type EnrollmentsQueryFilter struct {
 	Enabled        *bool    `json:"enabled,omitempty"`
 }
 
-// Pagination supports both limit/offset, as well as cursor.
-// For offset-based queries, Limit and Offset must be set. Use Offset = 0 for the first request.
-// For cursor-based queries, Limit and Cursor must be set. Use Cursor = "" for the first request.
+// Pagination supports either offset or cursor based pagination methods for results.
+// Backend implementations may support one or both methods, and may use either by default.
+// Offset and Cursor cannot both be set.
+// Backend implementations may have a default Limit, so omitting it may be possible.
+// For offset based queries, Offset must be set.
+// For cursor based queries, Cursor must be set.
 type Pagination struct {
-	Limit  int
-	Offset *int
-	Cursor string
+	Limit *int `json:"limit,omitempty"`
+	Offset *int  `json:"offset,omitempty"`
+	Cursor *string `json:"cursor,omitempty"`
+}
+
+// ValidErr returns any validation errors with p.
+func (p Pagination) ValidError() error {
+  if p.Cursor != nil && p.Offset != nil {
+  	return errors.New("cursor and offset both exist")
+  }
+  return nil
+}
+
+// Valid returns true if p is valid.
+func (p Pagination) Valid() bool {
+	return p.ValidErr() == nil
 }
 
 type EnrollmentQueryOptions struct {
 	// By default we do not include the Device Identity certificate in the response.
 	IncludeDeviceCert bool `json:"include_device_cert,omitempty"`
+	
+	// Include the device UnlockToken in the response. By default not included.
+	IncludeUnlockToken bool `json:"include_unlock_token,omitempty"`
 }
 
 // EnrollmentsQuery represents a query for MDM enrollments.
 type EnrollmentsQuery struct {
-	Filter     EnrollmentsQueryFilter `json:"filter,omitempty"`
-	Pagination Pagination             `json:"-"`
-	Options    EnrollmentQueryOptions `json:"options,omitempty"`
+	Filter    *EnrollmentsQueryFilter `json:"filter,omitempty"`
+	Pagination *Pagination             `json:"pagination,omitempty"`
+	Options    *EnrollmentQueryOptions `json:"options,omitempty"`
 }
 
-type DeviceEnrollment struct {
+type EnrollmentDevice struct {
 	SerialNumber string `json:"serial_number"`
+	
+	// Device Identity certificate in DER encoded form
+	DeviceCertPEM *string `json:"device_cert,omitempty"`
+
+	// Unlock Token of device, escrowed during initial and some subsequent Token Update check-in messages.
+	UnlockToken *string `json:"unlock_token,omitempty"`
 }
 
-type UserEnrollment struct {
+type EnrollmentUser struct {
 	UserShortName string `json:"user_short_name,omitempty"`
 	UserLongName  string `json:"user_long_name,omitempty"`
 }
@@ -76,12 +101,12 @@ type Enrollment struct {
 type EnrollmentsQueryResult struct {
 	Enrollments []*Enrollment `json:"enrollments"`
 
-	// NextToken is a cursor for pagination. If non-empty, more results may be fetched by
-	// setting this value in the NextToken field of a subsequent request.
-	NextToken string `json:"next_token,omitempty"`
+	// NextCursor is the enxt cursor for pagination. 
+	// If present and using cursor based pagination more results may be fetched by
+	// setting this value in the Cursor field of a subsequent request in the Pagination.
+	NextCursor *string `json:"next_cursor,omitempty"`
 
 	// Error is present if there was an error processing the request.
-	Error string `json:"error,omitempty"`
 }
 
 type EnrollmentsStore interface {

--- a/storage/pagination.go
+++ b/storage/pagination.go
@@ -1,0 +1,81 @@
+package storage
+
+import "errors"
+
+var (
+	ErrBothCursorAndOffset = errors.New("both cursor and offset set")
+	ErrOnlyCursor          = errors.New("only cursor-based pagination supported")
+	ErrOnlyOffset          = errors.New("only offset-based pagination supported")
+)
+
+// Pagination supports either offset or cursor based pagination methods for results.
+// Backend implementations may support one or both methods, and may use either by default.
+// Offset and Cursor cannot both be set.
+type Pagination struct {
+	// For offset based pagination queries, Offset must be set.
+	// Cannot be used with Cursor.
+	Offset *int `json:"offset,omitempty"`
+
+	// Backend implementations may have a default Limit, so omitting it may be possible.
+	Limit *int `json:"limit,omitempty"`
+
+	// For cursor based queries, Cursor must be set.
+	// Cannot be used with Offset.
+	// The initial cursor can be set to "" (empty string).
+	// The next cursor should be returned in the result.
+	Cursor *string `json:"cursor,omitempty"`
+}
+
+// PaginationNextCursor is for embedding in query result types.
+type PaginationNextCursor struct {
+	// When using cursor-based pagination (for backends that support it)
+	// this should contain the next cursor to use in the pagination.
+	NextCursor *string `json:"next_cursor,omitempty"`
+}
+
+// ValidErr returns validation errors for p.
+func (p *Pagination) ValidErr() error {
+	if p == nil {
+		// it's technically valid to have no pagination.
+		return nil
+	}
+	if p.Cursor != nil && p.Offset != nil {
+		return ErrBothCursorAndOffset
+	}
+	return nil
+}
+
+// Valid returns true if p is valid.
+func (p *Pagination) Valid() bool {
+	return p == nil || p.ValidErr() == nil
+}
+
+// DefaultOffsetLimit pulls out default offset and limit parameters from p.
+// If the limit in p is nil or less than 1, then default limit is returned,
+// otherwise the limit in p is returned.
+// Defaults of 0, 0 are otherwise returned.
+func (p *Pagination) DefaultOffsetLimit(defaultLimit int) (offset int, limit int) {
+	if p == nil {
+		limit = defaultLimit
+		return
+	}
+	if p.Offset != nil {
+		offset = *p.Offset
+	}
+	if p.Limit == nil || *p.Limit < 1 {
+		limit = defaultLimit
+	} else {
+		limit = *p.Limit
+	}
+	return
+}
+
+// ValidateDefaultOffsetLimit returns pagination details and errors, if present.
+func (p *Pagination) ValidateDefaultOffsetLimit(defaultLimit int) (cursor string, offset, limit int, err error) {
+	err = p.ValidErr()
+	offset, limit = p.DefaultOffsetLimit(defaultLimit)
+	if p != nil && p.Cursor != nil {
+		cursor = *p.Cursor
+	}
+	return
+}


### PR DESCRIPTION
This is an initial draft for an enrollments API (see https://github.com/micromdm/nanomdm/discussions/6).

So far this just includes a storage interface and OpenAPI spec - once these are finalized/agreed upon, I'll work on the implementation.

This API provides just enough query and response fields to be useful, and specifically avoids needing to reparse raw Authenticate, UserAuthenticate, or TokenUpdate bodies in the data store.