### PR TITLE
Avoid using view_queue to retrieve next command in PostgreSQL

### DIFF
--- a/storage/pgsql/schema.00001.sql
+++ b/storage/pgsql/schema.00001.sql
@@ -1,0 +1,7 @@
+CREATE INDEX idx_enrollment_queue_active_retrieval
+ON enrollment_queue (id, priority DESC, created_at)
+WHERE active = TRUE;
+
+CREATE INDEX idx_command_results_lookup
+ON command_results (id, command_uuid)
+INCLUDE (status, updated_at);


### PR DESCRIPTION
This change addresses high CPU usage in PostgreSQL when retrieving commands from large queues.

This follows commit c771e92 which implemented a similar optimization for MySQL by:

- Removing `view_queue` in favor of a direct table query + optimized indexes
- Using parameterized query instead of string concatenation which enables prepared statement plan reuse