### PR TITLE
Clarify ngrok Free plan behavior and suggest reverse proxy workaround on quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -137,6 +137,52 @@ tunnels:
     addr: 9000
 ```
 
+<details>
+  <summary><b>Note about ngrok Free plan behavior</b></summary>
+  
+Recent versions of ngrok (v3) on the Free plan may multiplex multiple HTTP
+tunnels onto the same public hostname. In this situation both tunnels may
+appear under the same URL, for example:
+
+```
+Forwarding     https://abcd1234.ngrok-free.dev -> localhost:8080
+Forwarding     https://abcd1234.ngrok-free.dev -> localhost:9000
+```
+
+This prevents using separate hostnames for the SCEP server and the NanoMDM
+server as described in this guide.
+
+A simple workaround is to run a local reverse proxy (such as nginx) and
+expose a single ngrok endpoint while routing requests by path:
+
+```
+/scep -> localhost:8080
+/mdm  -> localhost:9000
+```
+
+Example nginx configuration:
+
+```
+server {
+    listen 8000;
+
+    location /scep {
+        proxy_pass http://127.0.0.1:8080;
+    }
+
+    location /mdm {
+        proxy_pass http://127.0.0.1:9000;
+    }
+}
+```
+
+You can then expose the proxy with:
+```
+ngrok http 8000
+```
+
+</details>
+
 ### Upload Push Certificate
 
 To store the Push Certificate in NanoMDM we use the API:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -149,37 +149,12 @@ Forwarding     https://abcd1234.ngrok-free.dev -> localhost:8080
 Forwarding     https://abcd1234.ngrok-free.dev -> localhost:9000
 ```
 
-This prevents using separate hostnames for the SCEP server and the NanoMDM
-server as described in this guide.
+In this case, ngrok does not route requests between the tunnels based on the
+request path. As a result, exposing the SCEP server and the NanoMDM server
+through separate tunnels on the same hostname may not work as expected.
 
-A simple workaround is to run a local reverse proxy (such as nginx) and
-expose a single ngrok endpoint while routing requests by path:
-
-```
-/scep -> localhost:8080
-/mdm  -> localhost:9000
-```
-
-Example nginx configuration:
-
-```
-server {
-    listen 8000;
-
-    location /scep {
-        proxy_pass http://127.0.0.1:8080;
-    }
-
-    location /mdm {
-        proxy_pass http://127.0.0.1:9000;
-    }
-}
-```
-
-You can then expose the proxy with:
-```
-ngrok http 8000
-```
+If this happens, consider using a reverse proxy or another configuration
+that allows both services to be exposed through a single ngrok endpoint.
 
 </details>
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -137,8 +137,7 @@ tunnels:
     addr: 9000
 ```
 
-<details>
-  <summary><b>Note about ngrok Free plan behavior</b></summary>
+### Note about ngrok Free plan behavior
   
 Recent versions of ngrok (v3) on the Free plan may multiplex multiple HTTP
 tunnels onto the same public hostname. In this situation both tunnels may
@@ -155,8 +154,6 @@ through separate tunnels on the same hostname may not work as expected.
 
 If this happens, consider using a reverse proxy or another configuration
 that allows both services to be exposed through a single ngrok endpoint.
-
-</details>
 
 ### Upload Push Certificate
 


### PR DESCRIPTION
The current quickstart suggests using two ngrok tunnels for the SCEP server
and NanoMDM server and provides a workaround using the `tunnels` stanza
when the user encounters the "1 simultaneous ngrok agent" limitation.

However, with modern versions of ngrok (v3) on the Free plan, multiple HTTP
tunnels may be multiplexed onto the same public hostname. In practice this
can result in output like:

```
Forwarding     https://abcd1234.ngrok-free.dev -> localhost:8080
Forwarding     https://abcd1234.ngrok-free.dev -> localhost:9000
```

In this situation both the SCEP server and NanoMDM server are exposed under
the same hostname, which prevents configuring separate URLs in the
enrollment profile as described later in this guide.

This PR adds a short note explaining this behavior and suggests a simple
workaround: running a local reverse proxy (e.g. nginx) and exposing a
single ngrok endpoint while routing paths to the appropriate backend
services.

Example routing:

    /scep -> localhost:8080
    /mdm  -> localhost:9000

This keeps the quickstart simple while allowing the guide to work correctly
with ngrok v3 Free accounts.