### PR TITLE
Add get to pushcert to retrieve cert details

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,6 +6,39 @@ servers:
   - url: http://[::1]:9000/
 paths:
   /v1/pushcert:
+    get:
+      description: Retrieve the topic and expiry of the stored APNs push certificate.
+      security:
+        - basicAuth: []
+      parameters:
+        - in: query
+          name: topic
+          required: true
+          schema:
+            type: string
+            example: 'com.apple.mgmt.External.e3b8ceac-1f18-2c8e-8a63-dd17d99435d9'
+          description: The APNs topic identifying which push certificate to retrieve.
+      responses:
+        '200':
+          description: The topic and expiry of the stored APNs certificate are returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushCertResponse'
+        '400':
+          description: Missing or invalid topic query parameter.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          description: Server error retrieving or parsing the stored APNs certificate.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     put:
       description: Upload APNs certificate and private key.
       security:

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -262,6 +262,8 @@ The MDM check-in endpoint, if enabled, needs to correspond to the `CheckInURL` k
 
 * Endpoint: `/v1/pushcert`
 
+#### Uploading (PUT)
+
 The push cert API endpoint allows for uploading an APNS push certificate. It takes a concatenated PEM-encoded APNs push certificate and private key as its HTTP body. Note the private key should not be encrypted. A quick way to utilize this endpoint is to use `curl`. For example:
 
 ```bash
@@ -272,6 +274,18 @@ $ cat /path/to/push.pem /path/to/push.key | curl -T - -u nanomdm:nanomdm 'http:/
 ```
 
 Here the `-T -` switch to `curl` tells it to take the standard-input and use it as the body for a PUT request to `/v1/pushcert`. We're also using `-u` to specify the API key (HTTP authentication). The server responded by telling us the topic that this Push certificate corresponds to.
+
+#### Retrieving (GET)
+
+To check the topic and expiry of an already-stored push certificate without re-uploading it, send a GET request with the `topic` query parameter:
+
+```bash
+$ curl -u nanomdm:nanomdm 'http://127.0.0.1:9000/v1/pushcert?topic=com.apple.mgmt.External.e3b8ceac-1f18-2c8e-8a63-dd17d99435d9'
+{
+	"topic": "com.apple.mgmt.External.e3b8ceac-1f18-2c8e-8a63-dd17d99435d9",
+	"not_after": "2026-01-07T04:04:46Z"
+}
+```
 
 ### Push
 

--- a/http/api/pushcert.go
+++ b/http/api/pushcert.go
@@ -17,6 +17,42 @@ import (
 	"github.com/micromdm/nanomdm/storage"
 )
 
+// NewRetrievePushCertHandler returns the topic and expiry of the stored APNs
+// push certificate identified by the required "topic" query parameter.
+// Example: GET /v1/pushcert?topic=com.apple.mgmt.External.xxxxx
+func NewRetrievePushCertHandler(store storage.PushCertStore, logger log.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
+
+		topic := r.URL.Query().Get("topic")
+		if topic == "" {
+			logAndWriteJSONError(logger, w, "get topic query param", errors.New("missing required query parameter: topic"), http.StatusBadRequest)
+			return
+		}
+
+		cert, _, err := store.RetrievePushCert(r.Context(), topic)
+		if err != nil {
+			logAndWriteJSONError(logger, w, "retrieve push cert", err, 0)
+			return
+		}
+
+		leaf, err := x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			logAndWriteJSONError(logger, w, "parse push cert", err, 0)
+			return
+		}
+
+		logger.Debug("msg", "retrieved push cert", "topic", topic)
+
+		out := &PushCertResponseJson{
+			Topic:    topic,
+			NotAfter: leaf.NotAfter,
+		}
+
+		writeJSON(w, out, http.StatusOK, logger)
+	}
+}
+
 // readPEMCertAndKey reads a PEM-encoded certificate and non-encrypted
 // private key from input bytes and returns the separate PEM certificate
 // and private key in cert and key respectively.

--- a/http/api/v1.go
+++ b/http/api/v1.go
@@ -44,13 +44,22 @@ func handlerName(endpoint string) string {
 // handlers should have that sub-path stripped from the request.
 // The logger is adorned with a "handler" key of the endpoint name.
 func HandleAPIv1(prefix string, mux Mux, logger log.Logger, store APIStorage, pusher push.Pusher) {
-	// register API handler for push cert storage/upload
+	// register API handlers for push cert retrieval (GET) and upload (PUT)
+	pushCertLogger := logger.With("handler", handlerName(APIEndpointPushCert))
+	pushCertPUT := NewStorePushCertHandler(store, pushCertLogger)
+	pushCertGET := NewRetrievePushCertHandler(store, pushCertLogger)
 	mux.Handle(
 		prefix+APIEndpointPushCert,
-		NewStorePushCertHandler(
-			store,
-			logger.With("handler", handlerName(APIEndpointPushCert)),
-		),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPut:
+				pushCertPUT.ServeHTTP(w, r)
+			case http.MethodGet:
+				pushCertGET.ServeHTTP(w, r)
+			default:
+				http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			}
+		}),
 	)
 
 	// register API handler for sending APNs push notifications


### PR DESCRIPTION
Adds
- http/api/pushcert.go - Added NewRetrievePushCertHandler: takes a ?topic= query param, calls store.RetrievePushCert, parses the leaf cert, and returns the same PushCertResponseJson shape (topic + not_after).
- http/api/v1.go - Replaced the single NewStorePushCertHandler registration with a method-dispatch wrapper on the same path: GET → retrieve, PUT → store, anything else → 405.

Updated: 
- docs/openapi.yaml - Added a get: operation under /v1/pushcert with a required topic query parameter and the same PushCertResponse schema.
- docs/operations-guide.md - Split the "Push Cert" section into "Uploading (PUT)" and "Retrieving (GET)" subsections with a curl example for the new get.