### PR TITLE
fix(nanopush): panic on GoAwayError code path

### DIFF
--- a/push/nanopush/provider.go
+++ b/push/nanopush/provider.go
@@ -86,7 +86,7 @@ func (p *Provider) do(ctx context.Context, pushInfo *mdm.Push) *push.Response {
 	var goAwayErr http2.GoAwayError
 	if errors.As(err, &goAwayErr) {
 		body := strings.NewReader(goAwayErr.DebugData)
-		return &push.Response{Err: newError(body, r.StatusCode)}
+		return &push.Response{Err: newError(body, int(goAwayErr.ErrCode))} // resp.StatusCode is not available so we use the err code from the GoAwayError
 	} else if err != nil {
 		return &push.Response{Err: err}
 	}

--- a/push/nanopush/provider_test.go
+++ b/push/nanopush/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/micromdm/nanomdm/mdm"
+	"golang.org/x/net/http2"
 )
 
 func TestPush(t *testing.T) {
@@ -107,4 +108,36 @@ func testPushDevices(t *testing.T, input [][]string) {
 		}
 	}
 
+}
+
+// goAwayDoer is a mock Doer that returns an http2.GoAwayError.
+type goAwayDoer struct{}
+
+func (d *goAwayDoer) Do(*http.Request) (*http.Response, error) {
+	return nil, http2.GoAwayError{
+		LastStreamID: 0,
+		ErrCode:      http2.ErrCodeNo,
+		DebugData:    "server shutting down",
+	}
+}
+
+func TestPanicOnGoAwayError(t *testing.T) {
+	prov := &Provider{
+		baseURL: "https://example.com",
+		client:  &goAwayDoer{},
+	}
+
+	pushInfo := &mdm.Push{
+		PushMagic: "47250C9C-1B37-4381-98A9-0B8315A441C7",
+		Topic:     "com.example.apns-topic",
+	}
+	pushInfo.SetTokenString("c2732227a1d8021cfaf781d71fb2f908c61f5861079a00954a5453f1d0281433")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("code panicked on GoAwayError, but should not")
+		}
+	}()
+
+	prov.Push(context.Background(), []*mdm.Push{pushInfo})
 }


### PR DESCRIPTION
This PR fixes a subtle (and most likely never hit) code panic.

The code path in the nanopush provider, used the r.StatusCode, which is not available. I'm not sure if we are okay with the error being built assumes it's an HTTP status code, but we instead pass the GoAway error code.