### PR TITLE
fix(nanopush): panic on nil, and unbounded goroutine spawning

### DIFF
--- a/push/nanopush/nanopush.go
+++ b/push/nanopush/nanopush.go
@@ -94,8 +94,12 @@ func WithExpiration(expiration time.Duration) Option {
 }
 
 // WithWorkers sets how many worker goroutines to use when sending pushes.
+// The default is 5. If workers is less than 1, it will be set to 1.
 func WithWorkers(workers int) Option {
 	return func(f *Factory) {
+		if workers < 1 {
+			workers = 1
+		}
 		f.workers = workers
 	}
 }

--- a/push/nanopush/provider.go
+++ b/push/nanopush/provider.go
@@ -116,7 +116,7 @@ func (p *Provider) pushSerial(ctx context.Context, pushInfos []*mdm.Push) (map[s
 func (p *Provider) pushConcurrent(ctx context.Context, pushInfos []*mdm.Push) (map[string]*push.Response, error) {
 	// don't start more workers than we have pushes to send
 	workers := p.workers
-	if len(pushInfos) > workers {
+	if len(pushInfos) < workers {
 		workers = len(pushInfos)
 	}
 

--- a/push/nanopush/provider.go
+++ b/push/nanopush/provider.go
@@ -147,6 +147,10 @@ func (p *Provider) pushConcurrent(ctx context.Context, pushInfos []*mdm.Push) (m
 	// start the "feeder" (queue source)
 	go func() {
 		for _, pushInfo := range pushInfos {
+			if pushInfo == nil {
+				continue
+			}
+
 			jobs <- pushInfo
 		}
 		close(jobs)

--- a/push/nanopush/provider_test.go
+++ b/push/nanopush/provider_test.go
@@ -37,6 +37,26 @@ func TestPush(t *testing.T) {
 	t.Run("multiple-push", func(t *testing.T) {
 		testPushDevices(t, devicePushInfoStrings)
 	})
+
+	// test nil push info does not panic
+	t.Run("nil-concurrent-push-info", func(t *testing.T) {
+		prov := &Provider{
+			baseURL: "https://example.com",
+			client:  http.DefaultClient,
+			workers: 2,
+		}
+
+		resp, err := prov.Push(context.Background(), []*mdm.Push{nil, nil})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+		if len(resp) != 0 {
+			t.Fatalf("expected empty response, got %d", len(resp))
+		}
+	})
 }
 
 func testPushDevices(t *testing.T, input [][]string) {
@@ -91,6 +111,7 @@ func testPushDevices(t *testing.T, input [][]string) {
 	prov := &Provider{
 		baseURL: server.URL,
 		client:  http.DefaultClient,
+		workers: 2,
 	}
 
 	resp, err := prov.Push(context.Background(), pushInfos)

--- a/push/nanopush/provider_test.go
+++ b/push/nanopush/provider_test.go
@@ -3,6 +3,7 @@ package nanopush
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,7 @@ func TestPush(t *testing.T) {
 	t.Run("nil-concurrent-push-info", func(t *testing.T) {
 		prov := &Provider{
 			baseURL: "https://example.com",
-			client:  http.DefaultClient,
+			client:  &errorDoer{},
 			workers: 2,
 		}
 
@@ -129,6 +130,12 @@ func testPushDevices(t *testing.T, input [][]string) {
 		}
 	}
 
+}
+
+type errorDoer struct{}
+
+func (d *errorDoer) Do(*http.Request) (*http.Response, error) {
+	return nil, errors.New("fake http error")
 }
 
 // goAwayDoer is a mock Doer that returns an http2.GoAwayError.


### PR DESCRIPTION
This PR fixes two issues:

1. Panic on nil pushInfo when pushing more than one deviceInfo (inside the pushConcurrent), and fixes it by not pushing a job if the pushInfo is nil.
2. The check logic was flipped to determine how many workers to spawn, rendering the preset worker boundary useless, if more pushInfo came through, it would spawn X amount of workers, now it caps at the workers boundary, or downsizes if less than that.