### PR TITLE
fix(mysql): recycle pooled connections + expose lifetime/idle options

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/micromdm/nanomdm/storage"
 	"github.com/micromdm/nanomdm/storage/allmulti"
@@ -139,6 +140,20 @@ func mysqlStorageConfig(dsn, options string, logger log.Logger) (*mysql.MySQLSto
 				} else if v != "0" {
 					return nil, fmt.Errorf("invalid value for delete option: %q", v)
 				}
+			case "conn_max_lifetime":
+				d, err := time.ParseDuration(v)
+				if err != nil {
+					return nil, fmt.Errorf("invalid value for conn_max_lifetime option: %w", err)
+				}
+				opts = append(opts, mysql.WithConnMaxLifetime(d))
+				logger.Debug("msg", "connection max lifetime", "duration", d.String())
+			case "conn_max_idle_time":
+				d, err := time.ParseDuration(v)
+				if err != nil {
+					return nil, fmt.Errorf("invalid value for conn_max_idle_time option: %w", err)
+				}
+				opts = append(opts, mysql.WithConnMaxIdleTime(d))
+				logger.Debug("msg", "connection max idle time", "duration", d.String())
 			default:
 				return nil, fmt.Errorf("invalid option: %q", k)
 			}

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -120,9 +120,9 @@ Options are specified as a comma-separated list of "key=value" pairs. The mysql 
 * `delete=1`, `delete=0`
   * This option turns on or off the command and response deleter. It is disabled by default. When enabled (with `delete=1`) command responses, queued commands, and commands themeselves will be deleted from the database after enrollments have responded to a command.
 * `conn_max_lifetime=duration`
-  * This option sets the maximum amount of time a pooled connection may be reused. The value is a [Go duration string](https://pkg.go.dev/time#ParseDuration) such as `30s`, `3m`, or `1h`. It defaults to `3m`. A value of `0` keeps connections forever.
+  * This option sets the maximum amount of time a pooled connection may be reused. The value is a [Go duration string](https://pkg.go.dev/time#ParseDuration) such as `30s`, `3m`, or `1h`. When unset, connection lifetime is left at database/sql's default (connections are reused indefinitely). A value of `0` keeps connections forever.
 * `conn_max_idle_time=duration`
-  * This option sets the maximum amount of time a pooled connection may sit idle before it is closed. The value is a duration string, as above. It defaults to `1m`. A value of `0` never closes connections due to idle time.
+  * This option sets the maximum amount of time a pooled connection may sit idle before it is closed. The value is a duration string, as above. When unset, idle time is left at database/sql's default (idle connections are not closed by age). A value of `0` never closes connections due to idle time.
 
 *Example:* `-storage mysql -storage-dsn nanomdm:nanomdm/mymdmdb -storage-options delete=1`
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -119,8 +119,14 @@ Options are specified as a comma-separated list of "key=value" pairs. The mysql 
 
 * `delete=1`, `delete=0`
   * This option turns on or off the command and response deleter. It is disabled by default. When enabled (with `delete=1`) command responses, queued commands, and commands themeselves will be deleted from the database after enrollments have responded to a command.
+* `conn_max_lifetime=duration`
+  * This option sets the maximum amount of time a pooled connection may be reused. The value is a [Go duration string](https://pkg.go.dev/time#ParseDuration) such as `30s`, `3m`, or `1h`. It defaults to `3m`. A value of `0` keeps connections forever.
+* `conn_max_idle_time=duration`
+  * This option sets the maximum amount of time a pooled connection may sit idle before it is closed. The value is a duration string, as above. It defaults to `1m`. A value of `0` never closes connections due to idle time.
 
 *Example:* `-storage mysql -storage-dsn nanomdm:nanomdm/mymdmdb -storage-options delete=1`
+
+*Example:* `-storage mysql -storage-dsn nanomdm:nanomdm/mymdmdb -storage-options conn_max_lifetime=30s,conn_max_idle_time=15s`
 
 #### pgsql storage backend
 

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -39,15 +39,13 @@ type MySQLStorage struct {
 }
 
 type config struct {
-	driver             string
-	dsn                string
-	db                 *sql.DB
-	logger             log.Logger
-	rm                 bool
-	connMaxLifetime    time.Duration
-	connMaxLifetimeSet bool
-	connMaxIdleTime    time.Duration
-	connMaxIdleTimeSet bool
+	driver          string
+	dsn             string
+	db              *sql.DB
+	logger          log.Logger
+	rm              bool
+	connMaxLifetime time.Duration
+	connMaxIdleTime time.Duration
 }
 
 type Option func(*config)
@@ -88,7 +86,6 @@ func WithDeleteCommands() Option {
 func WithConnMaxLifetime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxLifetime = d
-		c.connMaxLifetimeSet = true
 	}
 }
 
@@ -98,7 +95,6 @@ func WithConnMaxLifetime(d time.Duration) Option {
 func WithConnMaxIdleTime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxIdleTime = d
-		c.connMaxIdleTimeSet = true
 	}
 }
 
@@ -117,10 +113,10 @@ func New(opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
-	if cfg.connMaxLifetimeSet {
+	if cfg.connMaxLifetime != 0 {
 		cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
 	}
-	if cfg.connMaxIdleTimeSet {
+	if cfg.connMaxIdleTime != 0 {
 		cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
 	}
 	if err = cfg.db.Ping(); err != nil {

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -16,17 +16,14 @@ import (
 	"github.com/micromdm/nanolib/log/ctxlog"
 )
 
-// Default connection pool recycling. Pooled connections are recycled well
-// before the shortest idle timeout in the network path (the istio-proxy
-// sidecar reaps idle TCP connections at ~1h, Aurora's wait_timeout is longer).
-// Without this, database/sql hands out long-idle connections that the far end
-// has already closed, producing "broken pipe" writes and "closing bad idle
-// connection: EOF" errors. Override per-deployment with WithConnMaxLifetime /
-// WithConnMaxIdleTime when the path's idle timeout differs.
-const (
-	defaultConnMaxLifetime = 3 * time.Minute
-	defaultConnMaxIdleTime = 1 * time.Minute
-)
+// Connection pool recycling is left at database/sql's defaults unless
+// configured. Pooled connections should be recycled well before the shortest
+// idle timeout in the network path (the istio-proxy sidecar reaps idle TCP
+// connections at ~1h, Aurora's wait_timeout is longer). Without recycling,
+// database/sql hands out long-idle connections that the far end has already
+// closed, producing "broken pipe" writes and "closing bad idle connection:
+// EOF" errors. Set WithConnMaxLifetime / WithConnMaxIdleTime per-deployment to
+// enable recycling for the path's idle timeout.
 
 // Schema holds the schema for the NanoMDM MySQL storage.
 //
@@ -42,13 +39,15 @@ type MySQLStorage struct {
 }
 
 type config struct {
-	driver          string
-	dsn             string
-	db              *sql.DB
-	logger          log.Logger
-	rm              bool
-	connMaxLifetime time.Duration
-	connMaxIdleTime time.Duration
+	driver             string
+	dsn                string
+	db                 *sql.DB
+	logger             log.Logger
+	rm                 bool
+	connMaxLifetime    time.Duration
+	connMaxLifetimeSet bool
+	connMaxIdleTime    time.Duration
+	connMaxIdleTimeSet bool
 }
 
 type Option func(*config)
@@ -89,6 +88,7 @@ func WithDeleteCommands() Option {
 func WithConnMaxLifetime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxLifetime = d
+		c.connMaxLifetimeSet = true
 	}
 }
 
@@ -98,15 +98,14 @@ func WithConnMaxLifetime(d time.Duration) Option {
 func WithConnMaxIdleTime(d time.Duration) Option {
 	return func(c *config) {
 		c.connMaxIdleTime = d
+		c.connMaxIdleTimeSet = true
 	}
 }
 
 func New(opts ...Option) (*MySQLStorage, error) {
 	cfg := &config{
-		logger:          log.NopLogger,
-		driver:          "mysql",
-		connMaxLifetime: defaultConnMaxLifetime,
-		connMaxIdleTime: defaultConnMaxIdleTime,
+		logger: log.NopLogger,
+		driver: "mysql",
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -118,8 +117,12 @@ func New(opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
-	cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
-	cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
+	if cfg.connMaxLifetimeSet {
+		cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
+	}
+	if cfg.connMaxIdleTimeSet {
+		cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
+	}
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -7,12 +7,25 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/micromdm/nanomdm/cryptoutil"
 	"github.com/micromdm/nanomdm/mdm"
 
 	"github.com/micromdm/nanolib/log"
 	"github.com/micromdm/nanolib/log/ctxlog"
+)
+
+// Default connection pool recycling. Pooled connections are recycled well
+// before the shortest idle timeout in the network path (the istio-proxy
+// sidecar reaps idle TCP connections at ~1h, Aurora's wait_timeout is longer).
+// Without this, database/sql hands out long-idle connections that the far end
+// has already closed, producing "broken pipe" writes and "closing bad idle
+// connection: EOF" errors. Override per-deployment with WithConnMaxLifetime /
+// WithConnMaxIdleTime when the path's idle timeout differs.
+const (
+	defaultConnMaxLifetime = 3 * time.Minute
+	defaultConnMaxIdleTime = 1 * time.Minute
 )
 
 // Schema holds the schema for the NanoMDM MySQL storage.
@@ -29,11 +42,13 @@ type MySQLStorage struct {
 }
 
 type config struct {
-	driver string
-	dsn    string
-	db     *sql.DB
-	logger log.Logger
-	rm     bool
+	driver          string
+	dsn             string
+	db              *sql.DB
+	logger          log.Logger
+	rm              bool
+	connMaxLifetime time.Duration
+	connMaxIdleTime time.Duration
 }
 
 type Option func(*config)
@@ -68,8 +83,31 @@ func WithDeleteCommands() Option {
 	}
 }
 
+// WithConnMaxLifetime sets the maximum amount of time a connection may be
+// reused. It should be shorter than the shortest idle timeout in the network
+// path to the database. A non-positive value keeps connections forever.
+func WithConnMaxLifetime(d time.Duration) Option {
+	return func(c *config) {
+		c.connMaxLifetime = d
+	}
+}
+
+// WithConnMaxIdleTime sets the maximum amount of time a connection may be idle
+// before it is closed. A non-positive value never closes connections due to
+// idle time.
+func WithConnMaxIdleTime(d time.Duration) Option {
+	return func(c *config) {
+		c.connMaxIdleTime = d
+	}
+}
+
 func New(opts ...Option) (*MySQLStorage, error) {
-	cfg := &config{logger: log.NopLogger, driver: "mysql"}
+	cfg := &config{
+		logger:          log.NopLogger,
+		driver:          "mysql",
+		connMaxLifetime: defaultConnMaxLifetime,
+		connMaxIdleTime: defaultConnMaxIdleTime,
+	}
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -80,6 +118,8 @@ func New(opts ...Option) (*MySQLStorage, error) {
 			return nil, err
 		}
 	}
+	cfg.db.SetConnMaxLifetime(cfg.connMaxLifetime)
+	cfg.db.SetConnMaxIdleTime(cfg.connMaxIdleTime)
 	if err = cfg.db.Ping(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The MySQL storage pool was opened with no lifetime tuning, so database/sql retained idle connections indefinitely. The istio-proxy sidecar reaps idle TCP connections at ~1h (Aurora wait_timeout is longer), so nanomdm reused already-closed connections, producing "write: broken pipe" and "closing bad idle connection: EOF" errors.

Set ConnMaxLifetime/ConnMaxIdleTime with 3m/1m defaults, both well under the proxy idle timeout, and expose them as WithConnMaxLifetime / WithConnMaxIdleTime options plus conn_max_lifetime / conn_max_idle_time storage-option keys (parsed via time.ParseDuration) so the ceiling can be retuned per deployment without an image rebuild.

Also covers mdmenroll, which runs the same nanomdm binary.


