### PR TITLE
feat(nanopush): allow push providers to take in a custom APNs push url

### DIFF
--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -78,6 +78,7 @@ func main() {
 		flAuthProxy  = flag.String("auth-proxy-url", "", "Reverse proxy URL target for MDM-authenticated HTTP requests")
 		flUAZLChal   = flag.Bool("ua-zl-dc", false, "reply with zero-length DigestChallenge for UserAuthenticate")
 		flWHHMACKey  = flag.String("webhook-hmac-key", "", "attaches an HMAC HTTP header to each webhook request using this key")
+		flPushURL    = flag.String("push-url", "", "custom APNs push server URL (e.g. https://api.development.push.apple.com:2197)")
 	)
 	envflag.Parse("NANOMDM_", []string{"version", "dsn"})
 
@@ -242,8 +243,14 @@ func main() {
 			return nlhttp.NewSimpleBasicAuthHandler(h, apiUsername, *flAPIKey, "nanomdm")
 		})
 
+		opts := []nanopush.Option{}
+		if *flPushURL != "" {
+			logger.Info("msg", "custom push server URL specified", "url", *flPushURL)
+			opts = append(opts, nanopush.WithPushServerURL(*flPushURL))
+		}
+
 		// create our push provider and push service
-		pushProviderFactory := nanopush.NewFactory()
+		pushProviderFactory := nanopush.NewFactory(opts...)
 		pushService := pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, logger.With("service", "push"))
 
 		// register API handlers

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -250,6 +250,12 @@ By default NanoMDM will respond to a `UserAuthenticate` message with an HTTP 410
 
 Note that the `UserAuthenticate` message is only for "directory" MDM users and not the "primary" MDM user enrollment. See also [Apple's discussion of UserAthenticate](https://developer.apple.com/documentation/devicemanagement/userauthenticate#discussion) for more information.
 
+### -push-url
+
+* Sets a custom APNs push server URL.
+
+By default nanomdm uses the production APNs push server URL. This flag allows you to specify a custom APNs push server URL (e.g. for development or testing). The URL must be a valid URL with a scheme and must not contain a path.
+
 ## HTTP endpoints & APIs
 
 ### MDM

--- a/push/buford/buford.go
+++ b/push/buford/buford.go
@@ -22,6 +22,7 @@ type bufordFactory struct {
 	workers           uint
 	expiration        time.Duration
 	newClientCallback NewClient
+	pushServerURL     *string
 }
 
 type Option func(*bufordFactory)
@@ -49,6 +50,13 @@ func WithNewClient(newClientCallback NewClient) Option {
 	}
 }
 
+// WithPushServerURL sets the APNs server URL for the push notifications.
+func WithPushServerURL(pushServerURL string) Option {
+	return func(f *bufordFactory) {
+		f.pushServerURL = &pushServerURL
+	}
+}
+
 // NewPushProviderFactory creates a new instance that can spawn buford Services
 func NewPushProviderFactory(opts ...Option) *bufordFactory {
 	factory := &bufordFactory{
@@ -72,8 +80,18 @@ func (f *bufordFactory) NewPushProvider(cert *tls.Certificate) (push.PushProvide
 	if err != nil {
 		return nil, err
 	}
+
+	pushServerURL := bufordpush.Production
+	if f.pushServerURL != nil {
+		pushServerURL = *f.pushServerURL
+
+		if err := push.ValidateCustomPushServerURL(pushServerURL); err != nil {
+			return nil, err
+		}
+	}
+
 	prov := &bufordPushProvider{
-		service:    bufordpush.NewService(client, bufordpush.Production),
+		service:    bufordpush.NewService(client, pushServerURL),
 		expiration: f.expiration,
 		workers:    f.workers,
 	}

--- a/push/nanopush/nanopush.go
+++ b/push/nanopush/nanopush.go
@@ -71,9 +71,10 @@ func defaultNewClient(cert *tls.Certificate) (*http.Client, error) {
 
 // Factory instantiates new PushProviders.
 type Factory struct {
-	newClient  NewClient
-	expiration time.Duration
-	workers    int
+	newClient     NewClient
+	expiration    time.Duration
+	workers       int
+	pushServerURL *string
 }
 
 type Option func(*Factory)
@@ -104,6 +105,13 @@ func WithWorkers(workers int) Option {
 	}
 }
 
+// WithPushServerURL sets the APNs server URL for the push notifications.
+func WithPushServerURL(pushServerURL string) Option {
+	return func(f *Factory) {
+		f.pushServerURL = &pushServerURL
+	}
+}
+
 // NewFactory creates a new Factory.
 func NewFactory(opts ...Option) *Factory {
 	f := &Factory{
@@ -118,10 +126,18 @@ func NewFactory(opts ...Option) *Factory {
 
 // NewPushProvider generates a new PushProvider given a tls keypair.
 func (f *Factory) NewPushProvider(cert *tls.Certificate) (push.PushProvider, error) {
+	pushServerURL := Production
+	if f.pushServerURL != nil {
+		pushServerURL = *f.pushServerURL
+		if err := push.ValidateCustomPushServerURL(pushServerURL); err != nil {
+			return nil, err
+		}
+	}
+
 	p := &Provider{
 		expiration: f.expiration,
 		workers:    f.workers,
-		baseURL:    Production,
+		baseURL:    pushServerURL,
 	}
 	var err error
 	p.client, err = f.newClient(cert)

--- a/push/push.go
+++ b/push/push.go
@@ -5,6 +5,8 @@ package push
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"net/url"
 
 	"github.com/micromdm/nanomdm/mdm"
 )
@@ -30,4 +32,19 @@ type PushProvider interface {
 // PushProviderFactory generates a new PushProvider given a tls keypair
 type PushProviderFactory interface {
 	NewPushProvider(*tls.Certificate) (PushProvider, error)
+}
+
+func ValidateCustomPushServerURL(pushServerURL string) error {
+	parsedURL, err := url.Parse(pushServerURL)
+	if err != nil {
+		return err
+	}
+	if parsedURL.Scheme == "" || (parsedURL.Scheme != "" && parsedURL.Host == "") {
+		return errors.New("push server URL must contain a scheme")
+	}
+	if parsedURL.Path != "" {
+		return errors.New("push server URL must not contain a path")
+	}
+
+	return nil
 }

--- a/push/push_test.go
+++ b/push/push_test.go
@@ -1,0 +1,29 @@
+package push
+
+import (
+	"testing"
+)
+
+func TestCustomPushServerURL(t *testing.T) {
+
+	t.Run("with path fails", func(t *testing.T) {
+		err := ValidateCustomPushServerURL("https://example.com/path/to/push")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("without path succeeds", func(t *testing.T) {
+		err := ValidateCustomPushServerURL("https://example.com:1234")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("without schema fails", func(t *testing.T) {
+		err := ValidateCustomPushServerURL("example.com:1234")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}


### PR DESCRIPTION
This PR allows to set a custom APNs URL for both Buford and Nanopush providers. Previously it was impossible to target the DEV url's or even a custom mock server.

The reason for this PR is to bring a change upstream that I think others (in niche scenarios) could benefit from, as we at Fleet have just made this change to target our mock APNs server when load testing with fake devices.

_One note, I didn't see a place to error out before we call the `NewPushProvider` which doesn't happen until the first push. Let me know if you have a better place for the validation._ 