### PR TITLE
perf(mysql): index queue and cert auth lookups

### DIFF
--- a/storage/mysql/schema.00010.sql
+++ b/storage/mysql/schema.00010.sql
@@ -1,0 +1,2 @@
+ALTER TABLE enrollment_queue ADD INDEX idx_queue_lookup (id, active, priority DESC, created_at);
+ALTER TABLE cert_auth_associations ADD INDEX idx_sha256 (sha256);

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -203,6 +203,7 @@ CREATE TABLE enrollment_queue (
     PRIMARY KEY (id, command_uuid),
 
     INDEX (priority DESC, created_at),
+    INDEX idx_queue_lookup (id, active, priority DESC, created_at),
 
     FOREIGN KEY (id)
         REFERENCES enrollments (id)
@@ -278,5 +279,6 @@ CREATE TABLE cert_auth_associations (
     PRIMARY KEY (id, sha256),
 
     CHECK (id != ''),
-    CHECK (sha256 != '')
+    CHECK (sha256 != ''),
+    INDEX idx_sha256 (sha256)
 );


### PR DESCRIPTION
Two hot lookups fall back to full scans on the current schema:

- RetrieveNextCommand filters enrollment_queue by `id` and `active`, then orders by `priority DESC, created_at`. The index added in `schema.00009` covers only the ORDER BY, leaving the filter unindexed. `idx_queue_lookup` covers both.
- `HasCertHash` and `EnrollmentFromHash` query cert_auth_associations by `sha256` alone. The (id, sha256) primary key cannot serve that as a leftmost prefix. `idx_sha256` does.

Applied to schema.sql for fresh installs and as a new `schema.00010.sql` delta for existing ones.

Assisted-by: Claude Code:claude-opus-5