### PR TITLE
fix(mysql): reference composite users key from enrollments FK

### DIFF
--- a/storage/mysql/schema.00011.sql
+++ b/storage/mysql/schema.00011.sql
@@ -1,0 +1,5 @@
+ALTER TABLE enrollments DROP FOREIGN KEY enrollments_ibfk_2;
+ALTER TABLE enrollments ADD CONSTRAINT enrollments_ibfk_2
+    FOREIGN KEY (user_id, device_id)
+    REFERENCES users (id, device_id)
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -114,8 +114,8 @@ CREATE TABLE enrollments (
         REFERENCES devices (id)
         ON DELETE CASCADE ON UPDATE CASCADE,
 
-    FOREIGN KEY (user_id)
-        REFERENCES users (id)
+    FOREIGN KEY (user_id, device_id)
+        REFERENCES users (id, device_id)
         ON DELETE CASCADE ON UPDATE CASCADE,
     UNIQUE (user_id),
 


### PR DESCRIPTION
MySQL 9 requires a foreign key's referenced column to be backed by a unique index. `enrollments.user_id` referenced `users(id)`, which is only the leftmost column of the composite `PRIMARY KEY (id, device_id)` and is intentionally non-unique, so MySQL 9 rejects the schema with:

```
ERROR 6125 (HY000): Failed to add the foreign key constraint. Missing
unique key for constraint 'enrollments_ibfk_2' in the referenced table
'users'
```

Reference the full composite key instead:

```sql
FOREIGN KEY (user_id, device_id)
    REFERENCES users (id, device_id)
```

This preserves the composite primary key design (`users.id` need not be unique) while satisfying MySQL 9's uniqueness requirement. Applied to `schema.sql` for fresh installs and as a `schema.00011.sql` delta for existing databases.

Fixes #202

Assisted-by: OpenCode:deepseek-v4-pro