### PR TITLE
refactor(pushcert): return PEM cert/key bytes from RetrievePushCert

### DIFF
--- a/http/api/pushcert.go
+++ b/http/api/pushcert.go
@@ -26,19 +26,19 @@ func NewRetrievePushCertHandler(store storage.PushCertStore, logger log.Logger) 
 
 		topic := r.URL.Query().Get("topic")
 		if topic == "" {
-			logAndWriteJSONError(logger, w, "get topic query param", errors.New("missing required query parameter: topic"), http.StatusBadRequest)
+			logAndWriteJSONError(logger, w, "parse topic query param", errors.New("missing required query parameter: topic"), http.StatusBadRequest)
 			return
 		}
 
-		cert, _, err := store.RetrievePushCert(r.Context(), topic)
+		pemCert, _, _, err := store.RetrievePushCert(r.Context(), topic)
 		if err != nil {
 			logAndWriteJSONError(logger, w, "retrieve push cert", err, 0)
 			return
 		}
 
-		leaf, err := x509.ParseCertificate(cert.Certificate[0])
+		cert, err := cryptoutil.DecodePEMCertificate(pemCert)
 		if err != nil {
-			logAndWriteJSONError(logger, w, "parse push cert", err, 0)
+			logAndWriteJSONError(logger, w, "decode and parse push cert", err, 0)
 			return
 		}
 
@@ -46,7 +46,7 @@ func NewRetrievePushCertHandler(store storage.PushCertStore, logger log.Logger) 
 
 		out := &PushCertResponseJson{
 			Topic:    topic,
-			NotAfter: leaf.NotAfter,
+			NotAfter: cert.NotAfter,
 		}
 
 		writeJSON(w, out, http.StatusOK, logger)

--- a/http/escrowkeyunlock/activationlock.go
+++ b/http/escrowkeyunlock/activationlock.go
@@ -2,6 +2,7 @@ package escrowkeyunlock
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -26,12 +27,17 @@ func DoEscrowKeyUnlock(ctx context.Context, store storage.PushCertStore, topic s
 		panic("nil params")
 	}
 
-	cert, _, err := store.RetrievePushCert(ctx, topic)
+	pemCert, pemKey, _, err := store.RetrievePushCert(ctx, topic)
 	if err != nil {
 		return nil, fmt.Errorf("retrieve push cert for topic: %s: %w", topic, err)
 	}
 
-	client, err = nanohttp.ClientWithCert(client, cert)
+	tlsCert, err := tls.X509KeyPair(pemCert, pemKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse key pair: %w", err)
+	}
+
+	client, err = nanohttp.ClientWithCert(client, &tlsCert)
 	if err != nil {
 		return nil, fmt.Errorf("adapting client for mTLS: %w", err)
 	}

--- a/push/service/service.go
+++ b/push/service/service.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"sync"
@@ -62,7 +63,7 @@ func (s *PushService) getProvider(ctx context.Context, topic string) (push.PushP
 			return prov.provider, nil
 		}
 	}
-	cert, staleToken, err := s.certStore.RetrievePushCert(ctx, topic)
+	pemCert, pemKey, staleToken, err := s.certStore.RetrievePushCert(ctx, topic)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving push cert for topic %q: %w", topic, err)
 	}
@@ -70,7 +71,13 @@ func (s *PushService) getProvider(ctx context.Context, topic string) (push.PushP
 		"msg", "retrieved push cert",
 		"topic", topic,
 	)
-	newProvider, err := s.providerFactory.NewPushProvider(cert)
+
+	cert, err := tls.X509KeyPair(pemCert, pemKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse key pair: %w", err)
+	}
+
+	newProvider, err := s.providerFactory.NewPushProvider(&cert)
 	if err != nil {
 		return nil, fmt.Errorf("creating new push provider: %w", err)
 	}

--- a/storage/allmulti/pushcert.go
+++ b/storage/allmulti/pushcert.go
@@ -2,7 +2,6 @@ package allmulti
 
 import (
 	"context"
-	"crypto/tls"
 
 	"github.com/micromdm/nanomdm/storage"
 )
@@ -15,19 +14,19 @@ func (ms *MultiAllStorage) IsPushCertStale(ctx context.Context, topic string, st
 }
 
 type retrievePushCertReturns struct {
-	cert       *tls.Certificate
-	staleToken string
+	pemCert, pemKey []byte
+	staleToken      string
 }
 
-func (ms *MultiAllStorage) RetrievePushCert(ctx context.Context, topic string) (cert *tls.Certificate, staleToken string, err error) {
+func (ms *MultiAllStorage) RetrievePushCert(ctx context.Context, topic string) (pemCert, pemKey []byte, staleToken string, err error) {
 	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
 		rets := new(retrievePushCertReturns)
 		var err error
-		rets.cert, rets.staleToken, err = s.RetrievePushCert(ctx, topic)
+		rets.pemCert, rets.pemKey, rets.staleToken, err = s.RetrievePushCert(ctx, topic)
 		return rets, err
 	})
 	rets := val.(*retrievePushCertReturns)
-	return rets.cert, rets.staleToken, err
+	return rets.pemCert, rets.pemKey, rets.staleToken, err
 }
 
 func (ms *MultiAllStorage) StorePushCert(ctx context.Context, pemCert, pemKey []byte) error {

--- a/storage/file/pushcert.go
+++ b/storage/file/pushcert.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -12,7 +11,7 @@ import (
 )
 
 // RetrievePushCert is passed through to a new PushCertFileStorage
-func (s *FileStorage) RetrievePushCert(ctx context.Context, topic string) (*tls.Certificate, string, error) {
+func (s *FileStorage) RetrievePushCert(ctx context.Context, topic string) ([]byte, []byte, string, error) {
 	ps := &PushCertFileStorage{
 		certFilepath: path.Join(s.path, topic+".pem"),
 		keyFilepath:  path.Join(s.path, topic+".key"),
@@ -62,28 +61,24 @@ func (s *PushCertFileStorage) getPushCertStaleToken(filename string) (string, er
 }
 
 // RetrievePushCert reads the Push Certificate from disk
-func (s *PushCertFileStorage) RetrievePushCert(_ context.Context, topic string) (*tls.Certificate, string, error) {
+func (s *PushCertFileStorage) RetrievePushCert(_ context.Context, topic string) ([]byte, []byte, string, error) {
 	pemCert, err := ioutil.ReadFile(s.certFilepath)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 	certTopic, err := cryptoutil.TopicFromPEMCert(pemCert)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 	if certTopic != topic {
-		return nil, "", errors.New("certificate topic mismatch")
+		return nil, nil, "", errors.New("certificate topic mismatch")
 	}
 	pemKey, err := ioutil.ReadFile(s.keyFilepath)
 	if err != nil {
-		return nil, "", err
-	}
-	cert, err := tls.X509KeyPair(pemCert, pemKey)
-	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 	staleToken, err := s.getPushCertStaleToken(s.certFilepath)
-	return &cert, staleToken, err
+	return pemCert, pemKey, staleToken, err
 }
 
 // IsPushCertStale inspects staleToken to tell if our push certs are stale

--- a/storage/kv/pushcert.go
+++ b/storage/kv/pushcert.go
@@ -2,7 +2,6 @@ package kv
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"strconv"
@@ -24,7 +23,7 @@ func (s *KV) IsPushCertStale(ctx context.Context, topic string, staleToken strin
 }
 
 // RetrievePushCert retrieves the TLS certificate and private key from the KV store.
-func (s *KV) RetrievePushCert(ctx context.Context, topic string) (cert *tls.Certificate, staleToken string, err error) {
+func (s *KV) RetrievePushCert(ctx context.Context, topic string) (pemCert, pemKey []byte, staleToken string, err error) {
 	getMap, err := kv.GetMap(
 		ctx,
 		s.pushCert,
@@ -35,15 +34,10 @@ func (s *KV) RetrievePushCert(ctx context.Context, topic string) (cert *tls.Cert
 		},
 	)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 
-	tlsCert, err := tls.X509KeyPair(getMap[join(topic, keyPushCertPEM)], getMap[join(topic, keyPushCertKey)])
-	if err != nil {
-		return nil, "", err
-	}
-
-	return &tlsCert, string(getMap[join(topic, keyPushCertStaleToken)]), nil
+	return getMap[join(topic, keyPushCertPEM)], getMap[join(topic, keyPushCertKey)], string(getMap[join(topic, keyPushCertStaleToken)]), nil
 }
 
 // StorePushCert stores pemCert and pemKey by APNs topic in the KV store.

--- a/storage/mysql/pushcert.go
+++ b/storage/mysql/pushcert.go
@@ -2,13 +2,12 @@ package mysql
 
 import (
 	"context"
-	"crypto/tls"
 	"strconv"
 
 	"github.com/micromdm/nanomdm/cryptoutil"
 )
 
-func (s *MySQLStorage) RetrievePushCert(ctx context.Context, topic string) (*tls.Certificate, string, error) {
+func (s *MySQLStorage) RetrievePushCert(ctx context.Context, topic string) ([]byte, []byte, string, error) {
 	var certPEM, keyPEM []byte
 	var staleToken int
 	err := s.db.QueryRowContext(
@@ -17,13 +16,9 @@ func (s *MySQLStorage) RetrievePushCert(ctx context.Context, topic string) (*tls
 		topic,
 	).Scan(&certPEM, &keyPEM, &staleToken)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		return nil, "", err
-	}
-	return &cert, strconv.Itoa(staleToken), err
+	return certPEM, keyPEM, strconv.Itoa(staleToken), err
 }
 
 func (s *MySQLStorage) IsPushCertStale(ctx context.Context, topic, staleToken string) (bool, error) {

--- a/storage/pgsql/pushcert.go
+++ b/storage/pgsql/pushcert.go
@@ -2,13 +2,12 @@ package pgsql
 
 import (
 	"context"
-	"crypto/tls"
 	"strconv"
 
 	"github.com/micromdm/nanomdm/cryptoutil"
 )
 
-func (s *PgSQLStorage) RetrievePushCert(ctx context.Context, topic string) (*tls.Certificate, string, error) {
+func (s *PgSQLStorage) RetrievePushCert(ctx context.Context, topic string) ([]byte, []byte, string, error) {
 	var certPEM, keyPEM []byte
 	var staleToken int
 	err := s.db.QueryRowContext(
@@ -17,13 +16,9 @@ func (s *PgSQLStorage) RetrievePushCert(ctx context.Context, topic string) (*tls
 		topic,
 	).Scan(&certPEM, &keyPEM, &staleToken)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		return nil, "", err
-	}
-	return &cert, strconv.Itoa(staleToken), err
+	return certPEM, keyPEM, strconv.Itoa(staleToken), err
 }
 
 func (s *PgSQLStorage) IsPushCertStale(ctx context.Context, topic, staleToken string) (bool, error) {

--- a/storage/pushcert.go
+++ b/storage/pushcert.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"crypto/tls"
 )
 
 // PushCertStore retrieves APNs push certificates.
@@ -12,7 +11,7 @@ type PushCertStore interface {
 	// and should turn stale (and return true) if the certificate has
 	// changed—such as being renewed.
 	IsPushCertStale(ctx context.Context, topic string, staleToken string) (bool, error)
-	RetrievePushCert(ctx context.Context, topic string) (cert *tls.Certificate, staleToken string, err error)
+	RetrievePushCert(ctx context.Context, topic string) (pemCert, pemKey []byte, staleToken string, err error)
 }
 
 // PushCertStorer stores APNs push certificates.

--- a/test/e2e/pushcert.go
+++ b/test/e2e/pushcert.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"os"
@@ -55,7 +56,11 @@ func pushcert(t *testing.T, ctx context.Context, a pushCertUploader, store pushS
 		t.Fatal(err)
 	}
 
-	tlsCert, staleToken1, err := store.RetrievePushCert(ctx, topic)
+	pemCert, pemKey, staleToken1, err := store.RetrievePushCert(ctx, topic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsCert, err := tls.X509KeyPair(pemCert, pemKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +80,7 @@ func pushcert(t *testing.T, ctx context.Context, a pushCertUploader, store pushS
 		t.Fatal(err)
 	}
 
-	_, staleToken2, err := store.RetrievePushCert(ctx, topic)
+	_, _, staleToken2, err := store.RetrievePushCert(ctx, topic)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Change `PushCertStore.RetrievePushCert()` to return the raw PEM certificate and private key (`[]byte`) instead of a parsed `*tls.Certificate`. This decouples the storage backends from TLS parsing — dropping their `crypto/tls` dependency — and gives callers the original PEM bytes, which a parsed `tls.Certificate` cannot round-trip.

Returning the raw bytes makes the store/retrieve boundary a clean place to wrap the cert and key (for example, encrypting/decrypting the private key before it is persisted and/or after it is read back).

Updated the file, KV, MySQL, PostgreSQL, and allmulti backends, plus the e2e pushcert test.

`go test ./...` passes.

Assisted-by: OpenCode:deepseek-v4-pro