### PR TITLE
Implement get-enrollments and command queue inspect/delete APIs

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -36,6 +36,15 @@ type APIResult struct {
 	RequestType string `json:"request_type,omitempty"` // RequestType of the enqueued command.
 }
 
+// QueueAPIResult is the result of queue APIs.
+type QueueAPIResult struct {
+	// Status is the per-enrollment ID results of queue APIs.
+	// Map key is the enrollment ID.
+	Status map[string]*Error `json:"status,omitempty"`
+	// Error is present if there was a general error with the queue API call.
+	Error *Error `json:"error,omitempty"`
+}
+
 // Error distills the APIResult errors to a simple error or returns nil.
 // If there are more than one error for an enrollment ID the last error is returned.
 // Error tries to preserve at least one "real" error by way of wrapping.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -220,13 +220,63 @@ paths:
           description: Successful response
           content:
             application/json:
-              schema: 
+              schema:
                 type: object
-                properties: 
+                properties:
                   version:
                     type: string
                 example:
                   version: "v0.1.0"
+  /v1/enrollments/query:
+    post:
+      description: Query MDM enrollments with filtering and pagination
+      security:
+        - basicAuth: []
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of enrollments to return
+          schema:
+            type: integer
+            default: 100
+        - name: offset
+          in: query
+          description: Number of enrollments to skip (for offset-based pagination)
+          schema:
+            type: integer
+        - name: cursor
+          in: query
+          description: Cursor for cursor-based pagination (mutually exclusive with offset)
+          schema:
+            type: string
+      requestBody:
+        description: Query parameters for filtering enrollments
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnrollmentsQuery'
+      responses:
+        '200':
+          description: Successful query response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnrollmentsQueryResult'
+        '400':
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   parameters:
     idParam:
@@ -329,3 +379,134 @@ components:
           type: string
           description: Error response string.
           example: The sun is shining.
+    EnrollmentsQuery:
+      type: object
+      description: Query parameters for filtering enrollments.
+      properties:
+        filter:
+          $ref: '#/components/schemas/EnrollmentsQueryFilter'
+        options:
+          $ref: '#/components/schemas/EnrollmentQueryOptions'
+    EnrollmentsQueryFilter:
+      type: object
+      description: Filter criteria for enrollment queries.
+      properties:
+        ids:
+          type: array
+          description: Filter by enrollment IDs
+          items:
+            type: string
+          example: ['299BD49-1A0C-422C-B285-2E4FF087C673']
+        serials:
+          type: array
+          description: Filter by device serial numbers
+          items:
+            type: string
+          example: ['C8TJ500QF1MN']
+        user_short_names:
+          type: array
+          description: Filter by user short names (for user enrollments)
+          items:
+            type: string
+          example: ['jdoe']
+        types:
+          type: array
+          description: Filter by enrollment type strings
+          items:
+            type: string
+            enum: ['Device', 'User', 'User Enrollment (Device)', 'User Enrollment', 'Shared iPad']
+          example: ['Device']
+        enabled:
+          type: boolean
+          description: Filter by enrollment enabled status
+          example: true
+    EnrollmentQueryOptions:
+      type: object
+      description: Options for enrollment queries.
+      properties:
+        include_device_cert:
+          type: boolean
+          description: Include the device identity certificate in the response
+          default: false
+        include_unlock_token:
+          type: boolean
+          description: Include the unlock token in the response
+          default: false
+    EnrollmentsQueryResult:
+      type: object
+      description: Result of an enrollments query.
+      required:
+        - enrollments
+      properties:
+        enrollments:
+          type: array
+          description: List of enrollments matching the query
+          items:
+            $ref: '#/components/schemas/Enrollment'
+        next_cursor:
+          type: string
+          description: Cursor for the next page of results (if more results exist)
+          example: 'eyJpZCI6IjEyMyJ9'
+    Enrollment:
+      type: object
+      description: An MDM enrollment.
+      required:
+        - id
+        - type
+        - enabled
+        - token_update_tally
+        - last_seen
+      properties:
+        id:
+          type: string
+          description: Unique enrollment identifier
+          example: '299BD49-1A0C-422C-B285-2E4FF087C673'
+        type:
+          type: string
+          description: Enrollment type
+          enum: ['Device', 'User', 'User Enrollment (Device)', 'User Enrollment', 'Shared iPad']
+          example: 'Device'
+        device:
+          $ref: '#/components/schemas/DeviceEnrollment'
+        user:
+          $ref: '#/components/schemas/UserEnrollment'
+        enabled:
+          type: boolean
+          description: Whether the enrollment is currently enabled
+          example: true
+        token_update_tally:
+          type: integer
+          description: Count of TokenUpdate messages received
+          example: 5
+        last_seen:
+          type: string
+          format: date-time
+          description: Timestamp of last activity from this enrollment
+          example: '2024-01-15T10:30:00Z'
+    DeviceEnrollment:
+      type: object
+      description: Device-specific enrollment data.
+      properties:
+        serial_number:
+          type: string
+          description: Device serial number
+          example: 'C8TJ500QF1MN'
+        device_cert:
+          type: string
+          description: PEM-encoded device identity certificate (only if include_device_cert option is set)
+        unlock_token:
+          type: string
+          format: byte
+          description: Base64-encoded device unlock token (only if include_unlock_token option is set)
+    UserEnrollment:
+      type: object
+      description: User-specific enrollment data.
+      properties:
+        user_short_name:
+          type: string
+          description: User's short name
+          example: 'jdoe'
+        user_long_name:
+          type: string
+          description: User's display name
+          example: 'John Doe'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -227,6 +227,72 @@ paths:
                     type: string
                 example:
                   version: "v0.1.0"
+  /v1/queue/{id}:
+    get:
+      description: Retrieve queued MDM commands for a specific enrollment ID.
+      security:
+        - basicAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Enrollment ID of a device- or user-channel enrollment.
+          required: true
+          schema:
+            type: string
+            example: '299BD49-1A0C-422C-B285-2E4FF087C673'
+        - name: limit
+          in: query
+          description: Maximum number of commands to return
+          schema:
+            type: integer
+            default: 100
+        - name: offset
+          in: query
+          description: Number of commands to skip (for offset-based pagination)
+          schema:
+            type: integer
+        - name: cursor
+          in: query
+          description: Cursor for cursor-based pagination (mutually exclusive with offset)
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful query response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueQueryResult'
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/queue/{id*}:
+    delete:
+      description: Clear all queued MDM commands for one or more enrollment IDs.
+      security:
+        - basicAuth: []
+      parameters:
+        - $ref: '#/components/parameters/idParam'
+      responses:
+        '204':
+          description: All queued commands were successfully cleared.
+        '207':
+          $ref: '#/components/responses/QueueAPIResultSomeFailed'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/QueueAPIResultAllFailed'
   /v1/enrollments/query:
     post:
       description: Query MDM enrollments with filtering and pagination
@@ -321,6 +387,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/APIResult'
+    QueueAPIResultSomeFailed:
+      description: Some requests succeeded and some failed. Returns JSON queue API response object including errors.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/QueueAPIResult'
+    QueueAPIResultAllFailed:
+      description: All requests failed. Returns JSON queue API response object including errors.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/QueueAPIResult'
   schemas:
     APIResult:
       type: object
@@ -379,6 +457,55 @@ components:
           type: string
           description: Error response string.
           example: The sun is shining.
+    QueueQueryResult:
+      type: object
+      description: Result of a queue query.
+      required:
+        - commands
+      properties:
+        commands:
+          type: array
+          description: List of queued commands
+          items:
+            $ref: '#/components/schemas/QueueCommand'
+        next_cursor:
+          type: string
+          description: Cursor for the next page of results (if more results exist)
+        error:
+          type: string
+          description: Error message if the query failed
+    QueueCommand:
+      type: object
+      description: A queued MDM command.
+      required:
+        - command_uuid
+        - request_type
+      properties:
+        command_uuid:
+          type: string
+          description: Unique command identifier
+          format: uuid
+          example: 'fedd659e-fc3c-4e35-8bb1-c8f51ae542a5'
+        request_type:
+          type: string
+          description: The MDM command request type
+          example: 'ProfileList'
+        command:
+          type: string
+          format: byte
+          description: Base64-encoded raw command plist
+    QueueAPIResult:
+      type: object
+      description: Result of queue API operations.
+      properties:
+        status:
+          type: object
+          description: Per-enrollment ID results. Map key is the enrollment ID.
+          additionalProperties:
+            type: string
+        error:
+          type: string
+          description: General error message if the overall operation failed
     EnrollmentsQuery:
       type: object
       description: Query parameters for filtering enrollments.

--- a/http/api/enrollments.go
+++ b/http/api/enrollments.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/micromdm/nanolib/log"
+	"github.com/micromdm/nanolib/log/ctxlog"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultEnrollmentsLimit = 100
+
+// EnrollmentsQueryHandler handles POST requests to query enrollments.
+func EnrollmentsQueryHandler(store storage.EnrollmentsStore, logger log.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
+
+		// Parse query parameters for pagination
+		pagination := parsePaginationFromQuery(r)
+
+		// Parse request body for filter and options
+		var reqBody EnrollmentsQueryJson
+		if r.ContentLength > 0 {
+			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+				logAndWriteJSONError(logger, w, "decoding request body", err, http.StatusBadRequest)
+				return
+			}
+		}
+
+		// Build storage query
+		query := &storage.EnrollmentsQuery{
+			Pagination: pagination,
+		}
+
+		// Map filter from JSON to storage type
+		if reqBody.Filter != nil {
+			query.Filter = &storage.EnrollmentsQueryFilter{
+				IDs:            reqBody.Filter.IDs,
+				Serials:        reqBody.Filter.Serials,
+				UserShortNames: reqBody.Filter.UserShortNames,
+				Types:          reqBody.Filter.Types,
+				Enabled:        reqBody.Filter.Enabled,
+			}
+		}
+
+		// Map options from JSON to storage type
+		if reqBody.Options != nil {
+			query.Options = &storage.EnrollmentQueryOptions{
+				IncludeDeviceCert:  reqBody.Options.IncludeDeviceCert,
+				IncludeUnlockToken: reqBody.Options.IncludeUnlockToken,
+			}
+		}
+
+		// Validate pagination
+		if pagination != nil {
+			if err := pagination.ValidErr(); err != nil {
+				logAndWriteJSONError(logger, w, "invalid pagination", err, http.StatusBadRequest)
+				return
+			}
+		}
+
+		// Execute query
+		result, err := store.QueryEnrollments(r.Context(), query)
+		if err != nil {
+			logAndWriteJSONError(logger, w, "querying enrollments", err, http.StatusInternalServerError)
+			return
+		}
+
+		// Map result to JSON response
+		response := mapEnrollmentsResult(result)
+
+		writeJSON(w, response, http.StatusOK, logger)
+	}
+}
+
+// parsePaginationFromQuery parses pagination parameters from query string.
+func parsePaginationFromQuery(r *http.Request) *storage.Pagination {
+	q := r.URL.Query()
+
+	var pagination *storage.Pagination
+
+	if limitStr := q.Get("limit"); limitStr != "" {
+		if pagination == nil {
+			pagination = &storage.Pagination{}
+		}
+		if limit, err := strconv.Atoi(limitStr); err == nil {
+			pagination.Limit = &limit
+		}
+	}
+
+	if offsetStr := q.Get("offset"); offsetStr != "" {
+		if pagination == nil {
+			pagination = &storage.Pagination{}
+		}
+		if offset, err := strconv.Atoi(offsetStr); err == nil {
+			pagination.Offset = &offset
+		}
+	}
+
+	if cursor := q.Get("cursor"); cursor != "" {
+		if pagination == nil {
+			pagination = &storage.Pagination{}
+		}
+		pagination.Cursor = &cursor
+	}
+
+	return pagination
+}
+
+// mapEnrollmentsResult maps storage result to JSON response.
+func mapEnrollmentsResult(result *storage.EnrollmentsQueryResult) *EnrollmentsQueryResultJson {
+	if result == nil {
+		return &EnrollmentsQueryResultJson{
+			Enrollments: []EnrollmentJson{},
+		}
+	}
+
+	enrollments := make([]EnrollmentJson, 0, len(result.Enrollments))
+	for _, e := range result.Enrollments {
+		enrollment := EnrollmentJson{
+			ID:               e.ID,
+			Type:             e.Type.String(),
+			Enabled:          e.Enabled,
+			TokenUpdateTally: e.TokenUpdateTally,
+			LastSeen:         e.LastSeen,
+		}
+
+		if e.Device != nil {
+			enrollment.Device = &DeviceEnrollmentJson{
+				SerialNumber: e.Device.SerialNumber,
+				DeviceCert:   e.Device.DeviceCert,
+				UnlockToken:  e.Device.UnlockToken,
+			}
+		}
+
+		if e.User != nil {
+			enrollment.User = &UserEnrollmentJson{
+				UserShortName: e.User.UserShortName,
+				UserLongName:  e.User.UserLongName,
+			}
+		}
+
+		enrollments = append(enrollments, enrollment)
+	}
+
+	response := &EnrollmentsQueryResultJson{
+		Enrollments: enrollments,
+		NextCursor:  result.NextCursor,
+	}
+
+	return response
+}
+
+// EnrollmentsQueryJson is the JSON request body for enrollment queries.
+type EnrollmentsQueryJson struct {
+	Filter  *EnrollmentsQueryFilterJson  `json:"filter,omitempty"`
+	Options *EnrollmentQueryOptionsJson `json:"options,omitempty"`
+}
+
+// EnrollmentsQueryFilterJson is the JSON filter for enrollment queries.
+type EnrollmentsQueryFilterJson struct {
+	IDs            []string `json:"ids,omitempty"`
+	Serials        []string `json:"serials,omitempty"`
+	UserShortNames []string `json:"user_short_names,omitempty"`
+	Types          []string `json:"types,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+}
+
+// EnrollmentQueryOptionsJson is the JSON options for enrollment queries.
+type EnrollmentQueryOptionsJson struct {
+	IncludeDeviceCert  bool `json:"include_device_cert,omitempty"`
+	IncludeUnlockToken bool `json:"include_unlock_token,omitempty"`
+}
+
+// EnrollmentsQueryResultJson is the JSON response for enrollment queries.
+type EnrollmentsQueryResultJson struct {
+	Enrollments []EnrollmentJson `json:"enrollments"`
+	NextCursor  *string          `json:"next_cursor,omitempty"`
+}
+
+// EnrollmentJson is the JSON representation of an enrollment.
+type EnrollmentJson struct {
+	ID               string                `json:"id"`
+	Type             string                `json:"type"`
+	Device           *DeviceEnrollmentJson `json:"device,omitempty"`
+	User             *UserEnrollmentJson   `json:"user,omitempty"`
+	Enabled          bool                  `json:"enabled"`
+	TokenUpdateTally int                   `json:"token_update_tally"`
+	LastSeen         time.Time             `json:"last_seen"`
+}
+
+// DeviceEnrollmentJson is the JSON representation of device enrollment data.
+type DeviceEnrollmentJson struct {
+	SerialNumber string `json:"serial_number,omitempty"`
+	DeviceCert   string `json:"device_cert,omitempty"`
+	UnlockToken  []byte `json:"unlock_token,omitempty"`
+}
+
+// UserEnrollmentJson is the JSON representation of user enrollment data.
+type UserEnrollmentJson struct {
+	UserShortName string `json:"user_short_name,omitempty"`
+	UserLongName  string `json:"user_long_name,omitempty"`
+}

--- a/http/api/queue.go
+++ b/http/api/queue.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	nanoapi "github.com/micromdm/nanomdm/api"
+	"github.com/micromdm/nanomdm/storage"
+
+	"github.com/micromdm/nanolib/log"
+	"github.com/micromdm/nanolib/log/ctxlog"
+)
+
+// QueueHandler handles GET and DELETE requests for the queue API.
+// GET retrieves queued commands for an enrollment ID.
+// DELETE clears queued commands for one or more enrollment IDs.
+//
+// Note the whole URL path is used as the identifier. This
+// probably necessitates stripping the URL prefix before using.
+func QueueHandler(store storage.CommandQueueAPIStore, logger log.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logger := ctxlog.Logger(r.Context(), logger)
+
+		switch r.Method {
+		case http.MethodGet:
+			handleQueueGet(w, r, store, logger)
+		case http.MethodDelete:
+			handleQueueDelete(w, r, store, logger)
+		default:
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// handleQueueGet retrieves queued commands for an enrollment ID.
+func handleQueueGet(w http.ResponseWriter, r *http.Request, store storage.CommandQueueAPIStore, logger log.Logger) {
+	id := r.URL.Path
+	if id == "" {
+		logAndWriteJSONError(logger, w, "missing enrollment id", nil, http.StatusBadRequest)
+		return
+	}
+
+	// Parse pagination from query parameters
+	pagination := parsePaginationFromQuery(r)
+
+	// Validate pagination
+	if pagination != nil {
+		if err := pagination.ValidErr(); err != nil {
+			logAndWriteJSONError(logger, w, "invalid pagination", err, http.StatusBadRequest)
+			return
+		}
+	}
+
+	query := &storage.QueueQuery{
+		ID:         id,
+		Pagination: pagination,
+	}
+
+	result, err := store.RetrieveQueuedCommands(r.Context(), query)
+	if err != nil {
+		logAndWriteJSONError(logger, w, "retrieving queued commands", err, http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, result, http.StatusOK, logger)
+}
+
+// handleQueueDelete clears queued commands for one or more enrollment IDs.
+func handleQueueDelete(w http.ResponseWriter, r *http.Request, store storage.CommandQueueAPIStore, logger log.Logger) {
+	idsRaw := r.URL.Path
+	if idsRaw == "" {
+		logAndWriteJSONError(logger, w, "missing enrollment id(s)", nil, http.StatusBadRequest)
+		return
+	}
+
+	ids := strings.Split(idsRaw, ",")
+
+	result := &nanoapi.QueueAPIResult{
+		Status: make(map[string]*nanoapi.Error),
+	}
+
+	var failCount int
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if err := store.ClearQueueByID(r.Context(), id); err != nil {
+			result.Status[id] = nanoapi.NewError(err)
+			failCount++
+		}
+	}
+
+	// Determine HTTP status based on results
+	header := http.StatusNoContent
+	if failCount > 0 && failCount < len(ids) {
+		// Some failed
+		header = http.StatusMultiStatus
+	} else if failCount > 0 {
+		// All failed
+		header = http.StatusInternalServerError
+	}
+
+	if header == http.StatusNoContent {
+		w.WriteHeader(header)
+		return
+	}
+
+	writeJSON(w, result, header, logger)
+}

--- a/http/api/v1.go
+++ b/http/api/v1.go
@@ -16,6 +16,7 @@ const (
 	APIEndpointEnqueue           = "/enqueue/" // note trailing slash
 	APIEndpointEscrowKeyUnlock   = "/escrowkeyunlock"
 	APIEndpointEnrollmentsQuery  = "/enrollments/query"
+	APIEndpointQueue             = "/queue/"   // note trailing slash
 )
 
 // Mux can register HTTP handlers.
@@ -32,6 +33,7 @@ type APIStorage interface {
 	storage.PushCertStorer
 	storage.CommandEnqueuer
 	storage.EnrollmentsStore
+	storage.CommandQueueAPIStore
 }
 
 func handlerName(endpoint string) string {
@@ -103,6 +105,18 @@ func HandleAPIv1(prefix string, mux Mux, logger log.Logger, store APIStorage, pu
 		EnrollmentsQueryHandler(
 			store,
 			logger.With("handler", handlerName(APIEndpointEnrollmentsQuery)),
+		),
+	)
+
+	// register API handler for queue inspect and delete
+	mux.Handle(
+		prefix+APIEndpointQueue,
+		http.StripPrefix( // we strip the prefix to use the path as an id
+			prefix+APIEndpointQueue,
+			QueueHandler(
+				store,
+				logger.With("handler", handlerName(APIEndpointQueue)),
+			),
 		),
 	)
 }

--- a/http/api/v1.go
+++ b/http/api/v1.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	APIEndpointPushCert        = "/pushcert"
-	APIEndpointPush            = "/push/"    // note trailing slash
-	APIEndpointEnqueue         = "/enqueue/" // note trailing slash
-	APIEndpointEscrowKeyUnlock = "/escrowkeyunlock"
+	APIEndpointPushCert          = "/pushcert"
+	APIEndpointPush              = "/push/"    // note trailing slash
+	APIEndpointEnqueue           = "/enqueue/" // note trailing slash
+	APIEndpointEscrowKeyUnlock   = "/escrowkeyunlock"
+	APIEndpointEnrollmentsQuery  = "/enrollments/query"
 )
 
 // Mux can register HTTP handlers.
@@ -30,6 +31,7 @@ type APIStorage interface {
 	storage.PushCertStore
 	storage.PushCertStorer
 	storage.CommandEnqueuer
+	storage.EnrollmentsStore
 }
 
 func handlerName(endpoint string) string {
@@ -93,5 +95,14 @@ func HandleAPIv1(prefix string, mux Mux, logger log.Logger, store APIStorage, pu
 	mux.Handle(
 		prefix+APIEndpointEscrowKeyUnlock,
 		NewEscrowKeyUnlockHandler(store, nil, logger.With("handler", handlerName(APIEndpointEscrowKeyUnlock))),
+	)
+
+	// register API handler for enrollments query
+	mux.Handle(
+		prefix+APIEndpointEnrollmentsQuery,
+		EnrollmentsQueryHandler(
+			store,
+			logger.With("handler", handlerName(APIEndpointEnrollmentsQuery)),
+		),
 	)
 }

--- a/storage/allmulti/enrollment.go
+++ b/storage/allmulti/enrollment.go
@@ -1,0 +1,18 @@
+package allmulti
+
+import (
+	"context"
+
+	"github.com/micromdm/nanomdm/storage"
+)
+
+// QueryEnrollments queries enrollments from the first storage backend.
+func (ms *MultiAllStorage) QueryEnrollments(ctx context.Context, req *storage.EnrollmentsQuery) (*storage.EnrollmentsQueryResult, error) {
+	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
+		return s.QueryEnrollments(ctx, req)
+	})
+	if val == nil {
+		return nil, err
+	}
+	return val.(*storage.EnrollmentsQueryResult), err
+}

--- a/storage/allmulti/queue_api.go
+++ b/storage/allmulti/queue_api.go
@@ -1,0 +1,26 @@
+package allmulti
+
+import (
+	"context"
+
+	"github.com/micromdm/nanomdm/storage"
+)
+
+// RetrieveQueuedCommands retrieves queued commands from the first storage backend.
+func (ms *MultiAllStorage) RetrieveQueuedCommands(ctx context.Context, req *storage.QueueQuery) (*storage.QueueQueryResult, error) {
+	val, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
+		return s.RetrieveQueuedCommands(ctx, req)
+	})
+	if val == nil {
+		return nil, err
+	}
+	return val.(*storage.QueueQueryResult), err
+}
+
+// ClearQueueByID clears all queued commands from the first storage backend.
+func (ms *MultiAllStorage) ClearQueueByID(ctx context.Context, id string) error {
+	_, err := ms.execStores(ctx, func(s storage.AllStorage) (interface{}, error) {
+		return nil, s.ClearQueueByID(ctx, id)
+	})
+	return err
+}

--- a/storage/enrollment.go
+++ b/storage/enrollment.go
@@ -1,0 +1,111 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/micromdm/nanomdm/mdm"
+)
+
+// EnrollmentsQueryFilter contains filter criteria for querying enrollments.
+type EnrollmentsQueryFilter struct {
+	// IDs filters by enrollment IDs.
+	IDs []string `json:"ids,omitempty"`
+
+	// Serials filters by device serial numbers.
+	Serials []string `json:"serials,omitempty"`
+
+	// UserShortNames filters by user short names (for user enrollments).
+	UserShortNames []string `json:"user_short_names,omitempty"`
+
+	// Types filters by enrollment type strings (e.g., "Device", "User").
+	Types []string `json:"types,omitempty"`
+
+	// Enabled filters by enrollment enabled status.
+	// If nil, no filter is applied.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// EnrollmentQueryOptions contains options for enrollment queries.
+type EnrollmentQueryOptions struct {
+	// IncludeDeviceCert includes the device identity certificate in the response.
+	IncludeDeviceCert bool `json:"include_device_cert,omitempty"`
+
+	// IncludeUnlockToken includes the unlock token in the response.
+	IncludeUnlockToken bool `json:"include_unlock_token,omitempty"`
+}
+
+// EnrollmentsQuery contains the query parameters for listing enrollments.
+type EnrollmentsQuery struct {
+	// Filter contains the filter criteria for the query.
+	Filter *EnrollmentsQueryFilter `json:"filter,omitempty"`
+
+	// Pagination contains pagination parameters.
+	Pagination *Pagination `json:"pagination,omitempty"`
+
+	// Options contains query options.
+	Options *EnrollmentQueryOptions `json:"options,omitempty"`
+}
+
+// DeviceEnrollment contains device-specific enrollment data.
+type DeviceEnrollment struct {
+	// SerialNumber is the device serial number.
+	SerialNumber string `json:"serial_number,omitempty"`
+
+	// DeviceCert is the PEM-encoded device identity certificate.
+	// Only populated if IncludeDeviceCert option is set.
+	DeviceCert string `json:"device_cert,omitempty"`
+
+	// UnlockToken is the device unlock token (iOS/iPadOS).
+	// Only populated if IncludeUnlockToken option is set.
+	UnlockToken []byte `json:"unlock_token,omitempty"`
+}
+
+// UserEnrollment contains user-specific enrollment data.
+type UserEnrollment struct {
+	// UserShortName is the user's short name.
+	UserShortName string `json:"user_short_name,omitempty"`
+
+	// UserLongName is the user's long (display) name.
+	UserLongName string `json:"user_long_name,omitempty"`
+}
+
+// Enrollment represents an MDM enrollment.
+type Enrollment struct {
+	// ID is the unique enrollment identifier.
+	ID string `json:"id"`
+
+	// Type is the enrollment type.
+	Type mdm.EnrollType `json:"type"`
+
+	// Device contains device-specific enrollment data.
+	// Present for device enrollments or as the parent for user enrollments.
+	Device *DeviceEnrollment `json:"device,omitempty"`
+
+	// User contains user-specific enrollment data.
+	// Only present for user-channel enrollments.
+	User *UserEnrollment `json:"user,omitempty"`
+
+	// Enabled indicates if the enrollment is currently enabled.
+	Enabled bool `json:"enabled"`
+
+	// TokenUpdateTally is the count of TokenUpdate messages received.
+	TokenUpdateTally int `json:"token_update_tally"`
+
+	// LastSeen is the timestamp of the last activity from this enrollment.
+	LastSeen time.Time `json:"last_seen"`
+}
+
+// EnrollmentsQueryResult contains the result of an enrollments query.
+type EnrollmentsQueryResult struct {
+	// Enrollments is the list of enrollments matching the query.
+	Enrollments []*Enrollment `json:"enrollments"`
+
+	PaginationNextCursor
+}
+
+// EnrollmentsStore retrieves enrollment data.
+type EnrollmentsStore interface {
+	// QueryEnrollments queries enrollments based on the provided request.
+	QueryEnrollments(ctx context.Context, req *EnrollmentsQuery) (*EnrollmentsQueryResult, error)
+}

--- a/storage/file/enrollment.go
+++ b/storage/file/enrollment.go
@@ -1,0 +1,223 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultEnrollmentsLimit = 100
+
+// QueryEnrollments queries enrollments based on the provided request.
+// Note: File storage does not support efficient querying, so this implementation
+// iterates through all enrollment directories and filters in memory.
+func (s *FileStorage) QueryEnrollments(ctx context.Context, req *storage.EnrollmentsQuery) (*storage.EnrollmentsQueryResult, error) {
+	result := &storage.EnrollmentsQueryResult{
+		Enrollments: make([]*storage.Enrollment, 0),
+	}
+
+	// Get pagination parameters
+	offset, limit := 0, defaultEnrollmentsLimit
+	if req != nil && req.Pagination != nil {
+		offset, limit = req.Pagination.DefaultOffsetLimit(defaultEnrollmentsLimit)
+	}
+
+	// List all enrollment directories
+	entries, err := os.ReadDir(s.path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter and paginate
+	matchCount := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		id := entry.Name()
+		enrollment, err := s.loadEnrollment(ctx, id, req)
+		if err != nil {
+			continue // Skip enrollments we can't load
+		}
+
+		// Apply filters
+		if !matchesFilter(enrollment, req) {
+			continue
+		}
+
+		matchCount++
+
+		// Apply offset
+		if matchCount <= offset {
+			continue
+		}
+
+		// Apply limit
+		if len(result.Enrollments) >= limit {
+			break
+		}
+
+		result.Enrollments = append(result.Enrollments, enrollment)
+	}
+
+	return result, nil
+}
+
+// loadEnrollment loads an enrollment by ID.
+func (s *FileStorage) loadEnrollment(ctx context.Context, id string, req *storage.EnrollmentsQuery) (*storage.Enrollment, error) {
+	e := s.newEnrollment(id)
+
+	// Check if this is a valid enrollment by checking for TokenUpdate file
+	exists, err := e.fileExists(TokenUpdateFilename)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		// Also check for Authenticate file
+		exists, err = e.fileExists(AuthenticateFilename)
+		if err != nil || !exists {
+			return nil, errors.New("not a valid enrollment")
+		}
+	}
+
+	enrollment := &storage.Enrollment{
+		ID: id,
+	}
+
+	// Determine type based on directory structure
+	// User enrollments have a parent device association
+	enrollment.Type = mdm.Device // Default to device
+
+	// Check if disabled
+	disabled, _ := e.fileExists(DisabledFilename)
+	enrollment.Enabled = !disabled
+
+	// Load token update tally
+	enrollment.TokenUpdateTally, _ = e.readNumericFile(TokenUpdateTallyFilename)
+
+	// Load last seen (use TokenUpdate file modification time as proxy)
+	if info, err := os.Stat(e.dirPrefix(TokenUpdateFilename)); err == nil {
+		enrollment.LastSeen = info.ModTime()
+	}
+
+	// Load device data
+	enrollment.Device = &storage.DeviceEnrollment{}
+
+	// Load serial number
+	if serialBytes, err := e.readFile(SerialNumberFilename); err == nil {
+		enrollment.Device.SerialNumber = strings.TrimSpace(string(serialBytes))
+	}
+
+	// Load optional data
+	includeDeviceCert := false
+	includeUnlockToken := false
+	if req != nil && req.Options != nil {
+		includeDeviceCert = req.Options.IncludeDeviceCert
+		includeUnlockToken = req.Options.IncludeUnlockToken
+	}
+
+	if includeDeviceCert {
+		if certBytes, err := e.readFile(IdentityCertFilename); err == nil {
+			enrollment.Device.DeviceCert = string(certBytes)
+		}
+	}
+
+	if includeUnlockToken {
+		if unlockBytes, err := e.readFile(UnlockTokenFilename); err == nil {
+			enrollment.Device.UnlockToken = unlockBytes
+		}
+	}
+
+	// Check for sub-enrollments (user channels)
+	subEnrollmentPath := filepath.Join(e.dir(), SubEnrollmentPathname)
+	if subEntries, err := os.ReadDir(subEnrollmentPath); err == nil && len(subEntries) > 0 {
+		// This device has user channel enrollments
+		// The sub-enrollments themselves are loaded separately
+	}
+
+	return enrollment, nil
+}
+
+// matchesFilter checks if an enrollment matches the query filter.
+func matchesFilter(enrollment *storage.Enrollment, req *storage.EnrollmentsQuery) bool {
+	if req == nil || req.Filter == nil {
+		return true
+	}
+
+	f := req.Filter
+
+	// Filter by IDs
+	if len(f.IDs) > 0 {
+		found := false
+		for _, id := range f.IDs {
+			if enrollment.ID == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by serials
+	if len(f.Serials) > 0 {
+		if enrollment.Device == nil {
+			return false
+		}
+		found := false
+		for _, serial := range f.Serials {
+			if enrollment.Device.SerialNumber == serial {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by user short names
+	if len(f.UserShortNames) > 0 {
+		if enrollment.User == nil {
+			return false
+		}
+		found := false
+		for _, name := range f.UserShortNames {
+			if enrollment.User.UserShortName == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by types
+	if len(f.Types) > 0 {
+		found := false
+		for _, t := range f.Types {
+			if enrollment.Type.String() == t {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by enabled status
+	if f.Enabled != nil && enrollment.Enabled != *f.Enabled {
+		return false
+	}
+
+	return true
+}

--- a/storage/file/queue_api.go
+++ b/storage/file/queue_api.go
@@ -1,0 +1,110 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultQueueLimit = 100
+
+// RetrieveQueuedCommands retrieves queued commands for the given enrollment ID.
+func (s *FileStorage) RetrieveQueuedCommands(_ context.Context, req *storage.QueueQuery) (*storage.QueueQueryResult, error) {
+	if req == nil || req.ID == "" {
+		return nil, fmt.Errorf("enrollment ID is required")
+	}
+
+	// Handle pagination
+	offset, limit := 0, defaultQueueLimit
+	if req.Pagination != nil {
+		offset, limit = req.Pagination.DefaultOffsetLimit(defaultQueueLimit)
+	}
+
+	result := &storage.QueueQueryResult{
+		Commands: make([]*storage.QueueCommand, 0),
+	}
+
+	e := s.newEnrollment(req.ID)
+
+	// Collect commands from both Queue and NotNow queues
+	count := 0
+	for _, sub := range []string{subNotNow, subQueue} {
+		q := e.newQueue(sub)
+		entries, err := os.ReadDir(q.dir())
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("reading queue directory: %w", err)
+		}
+
+		for _, entry := range entries {
+			name := entry.Name()
+			if !strings.HasSuffix(name, ".plist") || strings.HasSuffix(name, ".result.plist") {
+				continue
+			}
+
+			count++
+
+			// Apply offset
+			if count <= offset {
+				continue
+			}
+
+			// Apply limit
+			if len(result.Commands) >= limit {
+				return result, nil
+			}
+
+			raw, err := os.ReadFile(path.Join(q.dir(), name))
+			if err != nil {
+				return nil, fmt.Errorf("reading command file: %w", err)
+			}
+
+			cmd, err := mdm.DecodeCommand(raw)
+			if err != nil {
+				continue // skip malformed commands
+			}
+
+			result.Commands = append(result.Commands, storage.NewQueueCommand(
+				cmd.CommandUUID,
+				cmd.Command.RequestType,
+				cmd.Raw,
+			))
+		}
+	}
+
+	return result, nil
+}
+
+// ClearQueueByID clears all queued commands for the given enrollment ID.
+func (s *FileStorage) ClearQueueByID(_ context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("enrollment ID is required")
+	}
+
+	e := s.newEnrollment(id)
+	dest := e.newQueue(subInactive)
+
+	for _, q := range []*queue{e.newQueue(subQueue), e.newQueue(subNotNow)} {
+		raw, err := q.getNext()
+		for raw != nil && err == nil {
+			err = q.move(raw.CommandUUID, dest)
+			if err != nil {
+				return fmt.Errorf("clearing queue item: %w", err)
+			}
+			raw, err = q.getNext()
+		}
+		if err != nil {
+			return fmt.Errorf("clearing queue: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/storage/kv/enrollment.go
+++ b/storage/kv/enrollment.go
@@ -1,0 +1,266 @@
+package kv
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/micromdm/nanolib/storage/kv"
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultEnrollmentsLimit = 100
+
+// QueryEnrollments queries enrollments based on the provided request.
+// Note: KV storage does not support efficient querying, so this implementation
+// iterates through all enrollments and filters in memory.
+func (s *KV) QueryEnrollments(ctx context.Context, req *storage.EnrollmentsQuery) (*storage.EnrollmentsQueryResult, error) {
+	result := &storage.EnrollmentsQueryResult{
+		Enrollments: make([]*storage.Enrollment, 0),
+	}
+
+	// Get pagination parameters
+	offset, limit := 0, defaultEnrollmentsLimit
+	if req != nil && req.Pagination != nil {
+		offset, limit = req.Pagination.DefaultOffsetLimit(defaultEnrollmentsLimit)
+	}
+
+	// Collect all enrollment IDs by scanning for type keys
+	enrollmentIDs, err := s.collectEnrollmentIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter and paginate
+	matchCount := 0
+	for _, id := range enrollmentIDs {
+		enrollment, err := s.loadEnrollment(ctx, id, req)
+		if err != nil {
+			continue // Skip enrollments we can't load
+		}
+
+		// Apply filters
+		if !s.matchesFilter(enrollment, req) {
+			continue
+		}
+
+		matchCount++
+
+		// Apply offset
+		if matchCount <= offset {
+			continue
+		}
+
+		// Apply limit
+		if len(result.Enrollments) >= limit {
+			break
+		}
+
+		result.Enrollments = append(result.Enrollments, enrollment)
+	}
+
+	return result, nil
+}
+
+// collectEnrollmentIDs returns all enrollment IDs from the enrollments bucket.
+func (s *KV) collectEnrollmentIDs(ctx context.Context) ([]string, error) {
+	idSet := make(map[string]struct{})
+
+	// Iterate through all keys in the enrollments bucket to find unique IDs
+	// We look for keys that have the type suffix since every enrollment has a type
+	for key := range s.enrollments.KeysPrefix(ctx, "", nil) {
+		// Keys are in format "id.key_name"
+		// Find the ID portion (everything before the last separator)
+		if idx := strings.LastIndex(key, keySep); idx > 0 {
+			id := key[:idx]
+			// Check if this looks like an enrollment ID (not a nested key)
+			if !strings.Contains(id, keySep) || strings.Count(id, keySep) == 0 {
+				idSet[id] = struct{}{}
+			} else {
+				// For nested keys like "id.user_ch.subid", get the parent id
+				parts := strings.Split(key, keySep)
+				if len(parts) >= 2 {
+					idSet[parts[0]] = struct{}{}
+				}
+			}
+		}
+	}
+
+	ids := make([]string, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
+// loadEnrollment loads an enrollment by ID.
+func (s *KV) loadEnrollment(ctx context.Context, id string, req *storage.EnrollmentsQuery) (*storage.Enrollment, error) {
+	enrollment := &storage.Enrollment{
+		ID: id,
+	}
+
+	// Load type
+	typeBytes, err := s.enrollments.Get(ctx, join(id, keyEnrollmentType))
+	if err != nil {
+		if errors.Is(err, kv.ErrKeyNotFound) {
+			return nil, errors.New("enrollment not found")
+		}
+		return nil, err
+	}
+	enrollment.Type = parseEnrollType(string(typeBytes))
+
+	// Load enabled status (absence of disabled key means enabled)
+	_, err = s.enrollments.Get(ctx, join(id, keyEnrollmentDisabled))
+	enrollment.Enabled = errors.Is(err, kv.ErrKeyNotFound)
+
+	// Load token update tally
+	enrollment.TokenUpdateTally, _ = getTally(ctx, s.enrollments, id)
+
+	// Load last seen
+	lastSeenBytes, err := s.enrollments.Get(ctx, join(id, keyLastSeenAt))
+	if err == nil {
+		if ts, err := strconv.ParseInt(string(lastSeenBytes), 10, 64); err == nil {
+			enrollment.LastSeen = time.UnixMicro(ts)
+		}
+	}
+
+	// Load device data
+	enrollment.Device = &storage.DeviceEnrollment{}
+
+	// Get device ID (for user enrollments, use parent; for device enrollments, use self)
+	deviceID := id
+	if parentID, err := s.users.Get(ctx, join(id, keyUserDeviceChannel)); err == nil {
+		deviceID = string(parentID)
+		// This is a user enrollment, load user data
+		enrollment.User = &storage.UserEnrollment{}
+		// Note: user short/long names are not stored in KV backend
+	}
+
+	// Load serial number from devices bucket
+	if serialBytes, err := s.devices.Get(ctx, join(deviceID, keyDeviceSerial)); err == nil {
+		enrollment.Device.SerialNumber = string(serialBytes)
+	}
+
+	// Load optional data
+	includeDeviceCert := false
+	includeUnlockToken := false
+	if req != nil && req.Options != nil {
+		includeDeviceCert = req.Options.IncludeDeviceCert
+		includeUnlockToken = req.Options.IncludeUnlockToken
+	}
+
+	if includeDeviceCert {
+		if certBytes, err := s.devices.Get(ctx, join(deviceID, keyDeviceCert)); err == nil {
+			// Convert DER to PEM format
+			enrollment.Device.DeviceCert = string(certBytes) // Note: stored as DER in KV
+		}
+	}
+
+	if includeUnlockToken {
+		if unlockBytes, err := s.enrollments.Get(ctx, join(id, keyEnrollmentUnlockToken)); err == nil {
+			enrollment.Device.UnlockToken = unlockBytes
+		}
+	}
+
+	return enrollment, nil
+}
+
+// matchesFilter checks if an enrollment matches the query filter.
+func (s *KV) matchesFilter(enrollment *storage.Enrollment, req *storage.EnrollmentsQuery) bool {
+	if req == nil || req.Filter == nil {
+		return true
+	}
+
+	f := req.Filter
+
+	// Filter by IDs
+	if len(f.IDs) > 0 {
+		found := false
+		for _, id := range f.IDs {
+			if enrollment.ID == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by serials
+	if len(f.Serials) > 0 {
+		if enrollment.Device == nil {
+			return false
+		}
+		found := false
+		for _, serial := range f.Serials {
+			if enrollment.Device.SerialNumber == serial {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by user short names
+	if len(f.UserShortNames) > 0 {
+		if enrollment.User == nil {
+			return false
+		}
+		found := false
+		for _, name := range f.UserShortNames {
+			if enrollment.User.UserShortName == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by types
+	if len(f.Types) > 0 {
+		found := false
+		for _, t := range f.Types {
+			if enrollment.Type.String() == t {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Filter by enabled status
+	if f.Enabled != nil && enrollment.Enabled != *f.Enabled {
+		return false
+	}
+
+	return true
+}
+
+// parseEnrollType converts a string enrollment type to mdm.EnrollType.
+func parseEnrollType(s string) mdm.EnrollType {
+	switch s {
+	case "Device":
+		return mdm.Device
+	case "User":
+		return mdm.User
+	case "User Enrollment (Device)":
+		return mdm.UserEnrollmentDevice
+	case "User Enrollment":
+		return mdm.UserEnrollment
+	case "Shared iPad":
+		return mdm.SharediPad
+	default:
+		return 0
+	}
+}

--- a/storage/kv/queue_api.go
+++ b/storage/kv/queue_api.go
@@ -1,0 +1,89 @@
+package kv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/micromdm/nanolib/storage/kv"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultQueueLimit = 100
+
+// RetrieveQueuedCommands retrieves queued commands for the given enrollment ID.
+func (s *KV) RetrieveQueuedCommands(ctx context.Context, req *storage.QueueQuery) (*storage.QueueQueryResult, error) {
+	if req == nil || req.ID == "" {
+		return nil, fmt.Errorf("enrollment ID is required")
+	}
+
+	var b kv.CRUDBucket = s.queue
+	q := newQueue(b, req.ID, primaryQueue)
+
+	// Handle pagination
+	offset, limit := 0, defaultQueueLimit
+	if req.Pagination != nil {
+		offset, limit = req.Pagination.DefaultOffsetLimit(defaultQueueLimit)
+	}
+
+	result := &storage.QueueQueryResult{
+		Commands: make([]*storage.QueueCommand, 0),
+	}
+
+	count := 0
+	for cmdUUID, err := q.getFirst(ctx); cmdUUID != ""; cmdUUID, err = q.getNext(ctx, cmdUUID) {
+		if err != nil {
+			return nil, fmt.Errorf("getting item from queue: %w", err)
+		}
+
+		// Check if this command has a non-NotNow status (i.e., already completed)
+		status, err := b.Get(ctx, q.itemKeyName(cmdUUID, keyQueueStatus))
+		if err != nil && !errors.Is(err, kv.ErrKeyNotFound) {
+			return nil, fmt.Errorf("getting command status: %s: %w", cmdUUID, err)
+		}
+		if string(status) != "" && string(status) != "NotNow" {
+			continue // skip completed commands
+		}
+
+		count++
+
+		// Apply offset
+		if count <= offset {
+			continue
+		}
+
+		// Apply limit
+		if len(result.Commands) >= limit {
+			break
+		}
+
+		// Retrieve command data
+		m, err := kv.GetMap(ctx, b, []string{
+			join(cmdUUID, keyQueueRaw),
+			join(cmdUUID, keyQueueRequestType),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("retrieving command: %s: %w", cmdUUID, err)
+		}
+
+		result.Commands = append(result.Commands, storage.NewQueueCommand(
+			cmdUUID,
+			string(m[join(cmdUUID, keyQueueRequestType)]),
+			m[join(cmdUUID, keyQueueRaw)],
+		))
+	}
+
+	return result, nil
+}
+
+// ClearQueueByID clears all queued commands for the given enrollment ID.
+func (s *KV) ClearQueueByID(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("enrollment ID is required")
+	}
+
+	return kv.PerformCRUDBucketTxn(ctx, s.queue, func(ctx context.Context, b kv.CRUDBucket) error {
+		q := newQueue(b, id, primaryQueue)
+		return q.clear(ctx)
+	})
+}

--- a/storage/mysql/enrollment.go
+++ b/storage/mysql/enrollment.go
@@ -1,0 +1,249 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultEnrollmentsLimit = 100
+
+// QueryEnrollments queries enrollments based on the provided request.
+func (s *MySQLStorage) QueryEnrollments(ctx context.Context, req *storage.EnrollmentsQuery) (*storage.EnrollmentsQueryResult, error) {
+	// Build the query
+	query, args := s.buildEnrollmentsQuery(req)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying enrollments: %w", err)
+	}
+	defer rows.Close()
+
+	result := &storage.EnrollmentsQueryResult{
+		Enrollments: make([]*storage.Enrollment, 0),
+	}
+
+	for rows.Next() {
+		enrollment, err := s.scanEnrollment(rows, req)
+		if err != nil {
+			return nil, fmt.Errorf("scanning enrollment: %w", err)
+		}
+		result.Enrollments = append(result.Enrollments, enrollment)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating enrollments: %w", err)
+	}
+
+	return result, nil
+}
+
+// buildEnrollmentsQuery builds the SQL query and arguments for enrollments query.
+func (s *MySQLStorage) buildEnrollmentsQuery(req *storage.EnrollmentsQuery) (string, []interface{}) {
+	var args []interface{}
+	var conditions []string
+
+	// Determine which columns to select
+	selectCols := `
+		e.id,
+		e.type,
+		e.enabled,
+		e.token_update_tally,
+		e.last_seen_at,
+		d.serial_number,
+		u.user_short_name,
+		u.user_long_name`
+
+	// Add optional columns based on options
+	includeDeviceCert := false
+	includeUnlockToken := false
+	if req != nil && req.Options != nil {
+		includeDeviceCert = req.Options.IncludeDeviceCert
+		includeUnlockToken = req.Options.IncludeUnlockToken
+	}
+
+	if includeDeviceCert {
+		selectCols += `, d.identity_cert`
+	}
+	if includeUnlockToken {
+		selectCols += `, d.unlock_token`
+	}
+
+	// Build FROM and JOINs
+	fromClause := `
+		FROM enrollments e
+		INNER JOIN devices d ON e.device_id = d.id
+		LEFT JOIN users u ON e.user_id = u.id`
+
+	// Build WHERE conditions based on filter
+	if req != nil && req.Filter != nil {
+		f := req.Filter
+
+		if len(f.IDs) > 0 {
+			placeholders := make([]string, len(f.IDs))
+			for i, id := range f.IDs {
+				placeholders[i] = "?"
+				args = append(args, id)
+			}
+			conditions = append(conditions, fmt.Sprintf("e.id IN (%s)", strings.Join(placeholders, ", ")))
+		}
+
+		if len(f.Serials) > 0 {
+			placeholders := make([]string, len(f.Serials))
+			for i, serial := range f.Serials {
+				placeholders[i] = "?"
+				args = append(args, serial)
+			}
+			conditions = append(conditions, fmt.Sprintf("d.serial_number IN (%s)", strings.Join(placeholders, ", ")))
+		}
+
+		if len(f.UserShortNames) > 0 {
+			placeholders := make([]string, len(f.UserShortNames))
+			for i, name := range f.UserShortNames {
+				placeholders[i] = "?"
+				args = append(args, name)
+			}
+			conditions = append(conditions, fmt.Sprintf("u.user_short_name IN (%s)", strings.Join(placeholders, ", ")))
+		}
+
+		if len(f.Types) > 0 {
+			placeholders := make([]string, len(f.Types))
+			for i, t := range f.Types {
+				placeholders[i] = "?"
+				args = append(args, t)
+			}
+			conditions = append(conditions, fmt.Sprintf("e.type IN (%s)", strings.Join(placeholders, ", ")))
+		}
+
+		if f.Enabled != nil {
+			conditions = append(conditions, "e.enabled = ?")
+			args = append(args, *f.Enabled)
+		}
+	}
+
+	// Build WHERE clause
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	// Build ORDER BY and LIMIT
+	orderClause := " ORDER BY e.id ASC"
+
+	// Handle pagination
+	offset, limit := 0, defaultEnrollmentsLimit
+	if req != nil && req.Pagination != nil {
+		offset, limit = req.Pagination.DefaultOffsetLimit(defaultEnrollmentsLimit)
+	}
+
+	limitClause := fmt.Sprintf(" LIMIT %d OFFSET %d", limit, offset)
+
+	query := "SELECT" + selectCols + fromClause + whereClause + orderClause + limitClause
+
+	return query, args
+}
+
+// scanEnrollment scans a single enrollment row.
+func (s *MySQLStorage) scanEnrollment(rows *sql.Rows, req *storage.EnrollmentsQuery) (*storage.Enrollment, error) {
+	var (
+		id               string
+		enrollType       string
+		enabled          bool
+		tokenUpdateTally int
+		lastSeen         sql.NullTime
+		serialNumber     sql.NullString
+		userShortName    sql.NullString
+		userLongName     sql.NullString
+		identityCert     sql.NullString
+		unlockToken      []byte
+	)
+
+	// Determine which columns to scan based on options
+	includeDeviceCert := false
+	includeUnlockToken := false
+	if req != nil && req.Options != nil {
+		includeDeviceCert = req.Options.IncludeDeviceCert
+		includeUnlockToken = req.Options.IncludeUnlockToken
+	}
+
+	// Build scan destinations
+	scanDest := []interface{}{
+		&id,
+		&enrollType,
+		&enabled,
+		&tokenUpdateTally,
+		&lastSeen,
+		&serialNumber,
+		&userShortName,
+		&userLongName,
+	}
+
+	if includeDeviceCert {
+		scanDest = append(scanDest, &identityCert)
+	}
+	if includeUnlockToken {
+		scanDest = append(scanDest, &unlockToken)
+	}
+
+	if err := rows.Scan(scanDest...); err != nil {
+		return nil, err
+	}
+
+	enrollment := &storage.Enrollment{
+		ID:               id,
+		Type:             parseEnrollType(enrollType),
+		Enabled:          enabled,
+		TokenUpdateTally: tokenUpdateTally,
+	}
+
+	if lastSeen.Valid {
+		enrollment.LastSeen = lastSeen.Time
+	}
+
+	// Always include device data
+	enrollment.Device = &storage.DeviceEnrollment{}
+	if serialNumber.Valid {
+		enrollment.Device.SerialNumber = serialNumber.String
+	}
+	if includeDeviceCert && identityCert.Valid {
+		enrollment.Device.DeviceCert = identityCert.String
+	}
+	if includeUnlockToken && len(unlockToken) > 0 {
+		enrollment.Device.UnlockToken = unlockToken
+	}
+
+	// Include user data if present
+	if userShortName.Valid || userLongName.Valid {
+		enrollment.User = &storage.UserEnrollment{}
+		if userShortName.Valid {
+			enrollment.User.UserShortName = userShortName.String
+		}
+		if userLongName.Valid {
+			enrollment.User.UserLongName = userLongName.String
+		}
+	}
+
+	return enrollment, nil
+}
+
+// parseEnrollType converts a string enrollment type to mdm.EnrollType.
+func parseEnrollType(s string) mdm.EnrollType {
+	switch s {
+	case "Device":
+		return mdm.Device
+	case "User":
+		return mdm.User
+	case "User Enrollment (Device)":
+		return mdm.UserEnrollmentDevice
+	case "User Enrollment":
+		return mdm.UserEnrollment
+	case "Shared iPad":
+		return mdm.SharediPad
+	default:
+		return 0
+	}
+}

--- a/storage/mysql/queue_api.go
+++ b/storage/mysql/queue_api.go
@@ -1,0 +1,98 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultQueueLimit = 100
+
+// RetrieveQueuedCommands retrieves queued commands for the given enrollment ID.
+func (s *MySQLStorage) RetrieveQueuedCommands(ctx context.Context, req *storage.QueueQuery) (*storage.QueueQueryResult, error) {
+	if req == nil || req.ID == "" {
+		return nil, fmt.Errorf("enrollment ID is required")
+	}
+
+	// Handle pagination
+	offset, limit := 0, defaultQueueLimit
+	if req.Pagination != nil {
+		offset, limit = req.Pagination.DefaultOffsetLimit(defaultQueueLimit)
+	}
+
+	rows, err := s.db.QueryContext(
+		ctx, `
+SELECT
+    c.command_uuid,
+    c.request_type,
+    c.command
+FROM
+    enrollment_queue AS q
+    INNER JOIN commands AS c
+        ON q.command_uuid = c.command_uuid
+    LEFT JOIN command_results AS r
+        ON r.command_uuid = q.command_uuid AND r.id = q.id
+WHERE
+    q.id = ? AND
+    q.active = 1 AND
+    (r.status IS NULL OR r.status = 'NotNow')
+ORDER BY
+    q.priority DESC,
+    q.created_at
+LIMIT ? OFFSET ?;`,
+		req.ID, limit, offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying queue: %w", err)
+	}
+	defer rows.Close()
+
+	result := &storage.QueueQueryResult{
+		Commands: make([]*storage.QueueCommand, 0),
+	}
+
+	for rows.Next() {
+		var uuid, requestType string
+		var raw []byte
+		if err := rows.Scan(&uuid, &requestType, &raw); err != nil {
+			return nil, fmt.Errorf("scanning queue command: %w", err)
+		}
+		result.Commands = append(result.Commands, storage.NewQueueCommand(uuid, requestType, raw))
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating queue commands: %w", err)
+	}
+
+	return result, nil
+}
+
+// ClearQueueByID clears all queued commands for the given enrollment ID.
+func (s *MySQLStorage) ClearQueueByID(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("enrollment ID is required")
+	}
+
+	_, err := s.db.ExecContext(
+		ctx, `
+UPDATE
+    enrollment_queue AS q
+    INNER JOIN commands AS c
+        ON q.command_uuid = c.command_uuid
+    LEFT JOIN command_results r
+        ON r.command_uuid = q.command_uuid AND r.id = q.id
+SET
+    q.active = 0
+WHERE
+    q.id = ? AND
+    q.active = 1 AND
+    (r.status IS NULL OR r.status = 'NotNow');`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("clearing queue: %w", err)
+	}
+
+	return nil
+}

--- a/storage/pagination.go
+++ b/storage/pagination.go
@@ -1,0 +1,71 @@
+package storage
+
+import "errors"
+
+// Pagination errors.
+var (
+	// ErrBothCursorAndOffset is returned if both cursor and offset are set in a pagination request.
+	ErrBothCursorAndOffset = errors.New("both cursor and offset set")
+
+	// ErrOnlyCursor is returned if only cursor-based pagination is supported but offset was provided.
+	ErrOnlyCursor = errors.New("only cursor-based pagination supported")
+
+	// ErrOnlyOffset is returned if only offset-based pagination is supported but cursor was provided.
+	ErrOnlyOffset = errors.New("only offset-based pagination supported")
+)
+
+// Pagination contains pagination parameters for queries.
+type Pagination struct {
+	Offset *int    `json:"offset,omitempty"`
+	Limit  *int    `json:"limit,omitempty"`
+	Cursor *string `json:"cursor,omitempty"`
+}
+
+// PaginationNextCursor contains the cursor for the next page of results.
+type PaginationNextCursor struct {
+	NextCursor *string `json:"next_cursor,omitempty"`
+}
+
+// ValidErr returns an error if the pagination parameters are invalid.
+// Specifically, it checks that both cursor and offset are not set simultaneously.
+func (p *Pagination) ValidErr() error {
+	if p == nil {
+		return nil
+	}
+	if p.Cursor != nil && p.Offset != nil {
+		return ErrBothCursorAndOffset
+	}
+	return nil
+}
+
+// Valid returns true if the pagination parameters are valid.
+func (p *Pagination) Valid() bool {
+	return p.ValidErr() == nil
+}
+
+// DefaultOffsetLimit returns the offset and limit values with defaults applied.
+// If offset is not set, 0 is returned. If limit is not set, defaultLimit is returned.
+func (p *Pagination) DefaultOffsetLimit(defaultLimit int) (offset, limit int) {
+	if p == nil {
+		return 0, defaultLimit
+	}
+	if p.Offset != nil {
+		offset = *p.Offset
+	}
+	if p.Limit != nil {
+		limit = *p.Limit
+	} else {
+		limit = defaultLimit
+	}
+	return
+}
+
+// ValidateDefaultOffsetLimit validates the pagination and returns offset and limit with defaults.
+// Returns an error if both cursor and offset are set.
+func (p *Pagination) ValidateDefaultOffsetLimit(defaultLimit int) (offset, limit int, err error) {
+	if err = p.ValidErr(); err != nil {
+		return
+	}
+	offset, limit = p.DefaultOffsetLimit(defaultLimit)
+	return
+}

--- a/storage/pgsql/enrollment.go
+++ b/storage/pgsql/enrollment.go
@@ -1,0 +1,255 @@
+package pgsql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/micromdm/nanomdm/mdm"
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultEnrollmentsLimit = 100
+
+// QueryEnrollments queries enrollments based on the provided request.
+func (s *PgSQLStorage) QueryEnrollments(ctx context.Context, req *storage.EnrollmentsQuery) (*storage.EnrollmentsQueryResult, error) {
+	// Build the query
+	query, args := s.buildEnrollmentsQuery(req)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying enrollments: %w", err)
+	}
+	defer rows.Close()
+
+	result := &storage.EnrollmentsQueryResult{
+		Enrollments: make([]*storage.Enrollment, 0),
+	}
+
+	for rows.Next() {
+		enrollment, err := s.scanEnrollment(rows, req)
+		if err != nil {
+			return nil, fmt.Errorf("scanning enrollment: %w", err)
+		}
+		result.Enrollments = append(result.Enrollments, enrollment)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating enrollments: %w", err)
+	}
+
+	return result, nil
+}
+
+// buildEnrollmentsQuery builds the SQL query and arguments for enrollments query.
+func (s *PgSQLStorage) buildEnrollmentsQuery(req *storage.EnrollmentsQuery) (string, []interface{}) {
+	var args []interface{}
+	var conditions []string
+	argNum := 1
+
+	// Determine which columns to select
+	selectCols := `
+		e.id,
+		e.type,
+		e.enabled,
+		e.token_update_tally,
+		e.last_seen_at,
+		d.serial_number,
+		u.user_short_name,
+		u.user_long_name`
+
+	// Add optional columns based on options
+	includeDeviceCert := false
+	includeUnlockToken := false
+	if req != nil && req.Options != nil {
+		includeDeviceCert = req.Options.IncludeDeviceCert
+		includeUnlockToken = req.Options.IncludeUnlockToken
+	}
+
+	if includeDeviceCert {
+		selectCols += `, d.identity_cert`
+	}
+	if includeUnlockToken {
+		selectCols += `, d.unlock_token`
+	}
+
+	// Build FROM and JOINs
+	fromClause := `
+		FROM enrollments e
+		INNER JOIN devices d ON e.device_id = d.id
+		LEFT JOIN users u ON e.user_id = u.id`
+
+	// Build WHERE conditions based on filter
+	if req != nil && req.Filter != nil {
+		f := req.Filter
+
+		if len(f.IDs) > 0 {
+			placeholders := make([]string, len(f.IDs))
+			for i, id := range f.IDs {
+				placeholders[i] = fmt.Sprintf("$%d", argNum)
+				args = append(args, id)
+				argNum++
+			}
+			conditions = append(conditions, fmt.Sprintf("e.id IN (%s)", strings.Join(placeholders, ", ")))
+		}
+
+		if len(f.Serials) > 0 {
+			placeholders := make([]string, len(f.Serials))
+			for i, serial := range f.Serials {
+				placeholders[i] = fmt.Sprintf("$%d", argNum)
+				args = append(args, serial)
+				argNum++
+			}
+			conditions = append(conditions, fmt.Sprintf("d.serial_number IN (%s)", strings.Join(placeholders, ", ")))
+		}
+
+		if len(f.UserShortNames) > 0 {
+			placeholders := make([]string, len(f.UserShortNames))
+			for i, name := range f.UserShortNames {
+				placeholders[i] = fmt.Sprintf("$%d", argNum)
+				args = append(args, name)
+				argNum++
+			}
+			conditions = append(conditions, fmt.Sprintf("u.user_short_name IN (%s)", strings.Join(placeholders, ", ")))
+		}
+
+		if len(f.Types) > 0 {
+			placeholders := make([]string, len(f.Types))
+			for i, t := range f.Types {
+				placeholders[i] = fmt.Sprintf("$%d", argNum)
+				args = append(args, t)
+				argNum++
+			}
+			conditions = append(conditions, fmt.Sprintf("e.type IN (%s)", strings.Join(placeholders, ", ")))
+		}
+
+		if f.Enabled != nil {
+			conditions = append(conditions, fmt.Sprintf("e.enabled = $%d", argNum))
+			args = append(args, *f.Enabled)
+			argNum++
+		}
+	}
+
+	// Build WHERE clause
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	// Build ORDER BY and LIMIT
+	orderClause := " ORDER BY e.id ASC"
+
+	// Handle pagination
+	offset, limit := 0, defaultEnrollmentsLimit
+	if req != nil && req.Pagination != nil {
+		offset, limit = req.Pagination.DefaultOffsetLimit(defaultEnrollmentsLimit)
+	}
+
+	limitClause := fmt.Sprintf(" LIMIT %d OFFSET %d", limit, offset)
+
+	query := "SELECT" + selectCols + fromClause + whereClause + orderClause + limitClause
+
+	return query, args
+}
+
+// scanEnrollment scans a single enrollment row.
+func (s *PgSQLStorage) scanEnrollment(rows *sql.Rows, req *storage.EnrollmentsQuery) (*storage.Enrollment, error) {
+	var (
+		id               string
+		enrollType       string
+		enabled          bool
+		tokenUpdateTally int
+		lastSeen         sql.NullTime
+		serialNumber     sql.NullString
+		userShortName    sql.NullString
+		userLongName     sql.NullString
+		identityCert     sql.NullString
+		unlockToken      []byte
+	)
+
+	// Determine which columns to scan based on options
+	includeDeviceCert := false
+	includeUnlockToken := false
+	if req != nil && req.Options != nil {
+		includeDeviceCert = req.Options.IncludeDeviceCert
+		includeUnlockToken = req.Options.IncludeUnlockToken
+	}
+
+	// Build scan destinations
+	scanDest := []interface{}{
+		&id,
+		&enrollType,
+		&enabled,
+		&tokenUpdateTally,
+		&lastSeen,
+		&serialNumber,
+		&userShortName,
+		&userLongName,
+	}
+
+	if includeDeviceCert {
+		scanDest = append(scanDest, &identityCert)
+	}
+	if includeUnlockToken {
+		scanDest = append(scanDest, &unlockToken)
+	}
+
+	if err := rows.Scan(scanDest...); err != nil {
+		return nil, err
+	}
+
+	enrollment := &storage.Enrollment{
+		ID:               id,
+		Type:             parseEnrollType(enrollType),
+		Enabled:          enabled,
+		TokenUpdateTally: tokenUpdateTally,
+	}
+
+	if lastSeen.Valid {
+		enrollment.LastSeen = lastSeen.Time
+	}
+
+	// Always include device data
+	enrollment.Device = &storage.DeviceEnrollment{}
+	if serialNumber.Valid {
+		enrollment.Device.SerialNumber = serialNumber.String
+	}
+	if includeDeviceCert && identityCert.Valid {
+		enrollment.Device.DeviceCert = identityCert.String
+	}
+	if includeUnlockToken && len(unlockToken) > 0 {
+		enrollment.Device.UnlockToken = unlockToken
+	}
+
+	// Include user data if present
+	if userShortName.Valid || userLongName.Valid {
+		enrollment.User = &storage.UserEnrollment{}
+		if userShortName.Valid {
+			enrollment.User.UserShortName = userShortName.String
+		}
+		if userLongName.Valid {
+			enrollment.User.UserLongName = userLongName.String
+		}
+	}
+
+	return enrollment, nil
+}
+
+// parseEnrollType converts a string enrollment type to mdm.EnrollType.
+func parseEnrollType(s string) mdm.EnrollType {
+	switch s {
+	case "Device":
+		return mdm.Device
+	case "User":
+		return mdm.User
+	case "User Enrollment (Device)":
+		return mdm.UserEnrollmentDevice
+	case "User Enrollment":
+		return mdm.UserEnrollment
+	case "Shared iPad":
+		return mdm.SharediPad
+	default:
+		return 0
+	}
+}

--- a/storage/pgsql/queue_api.go
+++ b/storage/pgsql/queue_api.go
@@ -1,0 +1,98 @@
+package pgsql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/micromdm/nanomdm/storage"
+)
+
+const defaultQueueLimit = 100
+
+// RetrieveQueuedCommands retrieves queued commands for the given enrollment ID.
+func (s *PgSQLStorage) RetrieveQueuedCommands(ctx context.Context, req *storage.QueueQuery) (*storage.QueueQueryResult, error) {
+	if req == nil || req.ID == "" {
+		return nil, fmt.Errorf("enrollment ID is required")
+	}
+
+	// Handle pagination
+	offset, limit := 0, defaultQueueLimit
+	if req.Pagination != nil {
+		offset, limit = req.Pagination.DefaultOffsetLimit(defaultQueueLimit)
+	}
+
+	rows, err := s.db.QueryContext(
+		ctx, `
+SELECT
+    c.command_uuid,
+    c.request_type,
+    c.command
+FROM
+    enrollment_queue AS q
+    INNER JOIN commands AS c
+        ON q.command_uuid = c.command_uuid
+    LEFT JOIN command_results AS r
+        ON r.command_uuid = q.command_uuid AND r.id = q.id
+WHERE
+    q.id = $1 AND
+    q.active = TRUE AND
+    (r.status IS NULL OR r.status = 'NotNow')
+ORDER BY
+    q.priority DESC,
+    q.created_at
+LIMIT $2 OFFSET $3;`,
+		req.ID, limit, offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying queue: %w", err)
+	}
+	defer rows.Close()
+
+	result := &storage.QueueQueryResult{
+		Commands: make([]*storage.QueueCommand, 0),
+	}
+
+	for rows.Next() {
+		var uuid, requestType string
+		var raw []byte
+		if err := rows.Scan(&uuid, &requestType, &raw); err != nil {
+			return nil, fmt.Errorf("scanning queue command: %w", err)
+		}
+		result.Commands = append(result.Commands, storage.NewQueueCommand(uuid, requestType, raw))
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating queue commands: %w", err)
+	}
+
+	return result, nil
+}
+
+// ClearQueueByID clears all queued commands for the given enrollment ID.
+func (s *PgSQLStorage) ClearQueueByID(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("enrollment ID is required")
+	}
+
+	_, err := s.db.ExecContext(
+		ctx, `
+UPDATE enrollment_queue
+SET active = FALSE
+FROM enrollment_queue AS q
+    INNER JOIN commands AS c
+        ON q.command_uuid = c.command_uuid
+    LEFT JOIN command_results AS r
+        ON r.command_uuid = q.command_uuid AND r.id = q.id
+WHERE
+    enrollment_queue.id = $1 AND
+    enrollment_queue.active = TRUE AND
+    (r.status IS NULL OR r.status = 'NotNow') AND
+    enrollment_queue.id = q.id;`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("clearing queue: %w", err)
+	}
+
+	return nil
+}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/micromdm/nanomdm/mdm"
 )
@@ -16,4 +17,42 @@ type CommandAndReportResultsStore interface {
 // CommandEnqueuer is able to enqueue MDM commands.
 type CommandEnqueuer interface {
 	EnqueueCommand(ctx context.Context, id []string, cmd *mdm.Command) (map[string]error, error)
+}
+
+// QueueCommand represents a command in the queue for API responses.
+type QueueCommand struct {
+	CommandUUID string `json:"command_uuid"`
+	RequestType string `json:"request_type"`
+	// Command is the Base64-encoded raw command plist.
+	Command string `json:"command,omitempty"`
+}
+
+// NewQueueCommand creates a QueueCommand from the raw command data.
+func NewQueueCommand(uuid, requestType string, raw []byte) *QueueCommand {
+	return &QueueCommand{
+		CommandUUID: uuid,
+		RequestType: requestType,
+		Command:     base64.StdEncoding.EncodeToString(raw),
+	}
+}
+
+// QueueQuery contains the query parameters for retrieving queued commands.
+type QueueQuery struct {
+	ID         string
+	Pagination *Pagination
+}
+
+// QueueQueryResult is the result of a queue query.
+type QueueQueryResult struct {
+	Commands []*QueueCommand `json:"commands"`
+	PaginationNextCursor
+	Error string `json:"error,omitempty"`
+}
+
+// CommandQueueAPIStore retrieves and clears command queue data for the API.
+type CommandQueueAPIStore interface {
+	// RetrieveQueuedCommands returns queued commands for the given enrollment ID.
+	RetrieveQueuedCommands(ctx context.Context, req *QueueQuery) (*QueueQueryResult, error)
+	// ClearQueueByID clears all queued commands for the given enrollment ID.
+	ClearQueueByID(ctx context.Context, id string) error
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -20,6 +20,7 @@ type AllStorage interface {
 	StoreMigrator
 	TokenUpdateTallyStore
 	PushCertStorer
+	EnrollmentsStore
 }
 
 // ServiceStore stores & retrieves both command and check-in data.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -21,6 +21,7 @@ type AllStorage interface {
 	TokenUpdateTallyStore
 	PushCertStorer
 	EnrollmentsStore
+	CommandQueueAPIStore
 }
 
 // ServiceStore stores & retrieves both command and check-in data.


### PR DESCRIPTION
Implements the get-enrollments API and the command-queue inspect/delete API. This is a rebased, reviewed version of #239.

To keep review manageable, the change is reviewed as a stack of 6 smaller PRs on the fork, each under ~500 lines and each building on its own:

**Enrollments API**
1. WardsParadox/nanomdm#1 — `EnrollmentsStore` interface + pagination helpers
2. WardsParadox/nanomdm#2 — kv + file backends
3. WardsParadox/nanomdm#3 — mysql + pgsql backends
4. WardsParadox/nanomdm#4 — allmulti + `AllStorage` wiring + HTTP handler + routes + OpenAPI

**Command queue inspect/delete API**
5. WardsParadox/nanomdm#5 — `CommandQueueAPIStore` interface + kv + file backends
6. WardsParadox/nanomdm#6 — remaining backends + `AllStorage` wiring + HTTP + OpenAPI

This PR is the combined result of that stack, rebased onto current `main`. New interfaces are added to `AllStorage` only in the PR that also lands every backend implementing them, so each layer compiles on its own.

Kept as a draft until the per-layer review on the fork is complete.
